### PR TITLE
Cleanup addEventListener

### DIFF
--- a/.changeset/olive-rivers-try.md
+++ b/.changeset/olive-rivers-try.md
@@ -1,0 +1,5 @@
+---
+"runed": patch
+---
+
+Fix addEventListener overloads

--- a/packages/runed/src/lib/functions/useEventListener/useEventListener.svelte.ts
+++ b/packages/runed/src/lib/functions/useEventListener/useEventListener.svelte.ts
@@ -4,14 +4,14 @@ import { addEventListener } from "$lib/internal/utils/event.js";
 
 export function useEventListener<TEvent extends keyof WindowEventMap>(
 	target: MaybeBoxOrGetter<Window | null | undefined>,
-	event: TEvent,
+	event: TEvent | TEvent[],
 	handler: (this: Window, event: WindowEventMap[TEvent]) => unknown,
 	options?: boolean | AddEventListenerOptions
 ): void;
 
 export function useEventListener<TEvent extends keyof DocumentEventMap>(
 	target: MaybeBoxOrGetter<Document | null | undefined>,
-	event: TEvent,
+	event: TEvent | TEvent[],
 	handler: (this: Document, event: DocumentEventMap[TEvent]) => unknown,
 	options?: boolean | AddEventListenerOptions
 ): void;
@@ -21,21 +21,21 @@ export function useEventListener<
 	TEvent extends keyof HTMLElementEventMap,
 >(
 	target: MaybeBoxOrGetter<TElement | null | undefined>,
-	event: TEvent,
+	event: TEvent | TEvent[],
 	handler: (this: TElement, event: HTMLElementEventMap[TEvent]) => unknown,
 	options?: boolean | AddEventListenerOptions
 ): void;
 
 export function useEventListener(
 	target: MaybeBoxOrGetter<EventTarget | null | undefined>,
-	event: string,
+	event: string | string[],
 	handler: EventListenerOrEventListenerObject,
 	options?: boolean | AddEventListenerOptions
 ): void;
 
 export function useEventListener(
 	_target: MaybeBoxOrGetter<EventTarget | null | undefined>,
-	event: string,
+	event: string | string[],
 	handler: EventListenerOrEventListenerObject,
 	options?: boolean | AddEventListenerOptions
 ) {

--- a/packages/runed/src/lib/functions/useEventListener/useEventListener.svelte.ts
+++ b/packages/runed/src/lib/functions/useEventListener/useEventListener.svelte.ts
@@ -1,6 +1,7 @@
 import { box } from "../box/box.svelte.js";
 import type { MaybeBoxOrGetter } from "$lib/internal/types.js";
 import { addEventListener } from "$lib/internal/utils/event.js";
+
 export function useEventListener<TEvent extends keyof WindowEventMap>(
 	target: MaybeBoxOrGetter<Window | null | undefined>,
 	event: TEvent,

--- a/packages/runed/src/lib/functions/useEventListener/useEventListener.svelte.ts
+++ b/packages/runed/src/lib/functions/useEventListener/useEventListener.svelte.ts
@@ -2,6 +2,13 @@ import { box } from "../box/box.svelte.js";
 import type { MaybeBoxOrGetter } from "$lib/internal/types.js";
 import { addEventListener } from "$lib/internal/utils/event.js";
 
+/**
+ * Adds an event listener to the specified target element for the given event(s), and returns a function to remove it.
+ * @param target The target element to add the event listener to.
+ * @param event The event(s) to listen for.
+ * @param handler The function to be called when the event is triggered.
+ * @param options An optional object that specifies characteristics about the event listener.
+ */
 export function useEventListener<TEvent extends keyof WindowEventMap>(
 	target: MaybeBoxOrGetter<Window | null | undefined>,
 	event: TEvent | TEvent[],
@@ -16,6 +23,13 @@ export function useEventListener<TEvent extends keyof DocumentEventMap>(
 	options?: boolean | AddEventListenerOptions
 ): void;
 
+/**
+ * Adds an event listener to the specified target element for the given event(s), and returns a function to remove it.
+ * @param target The target element to add the event listener to.
+ * @param event The event(s) to listen for.
+ * @param handler The function to be called when the event is triggered.
+ * @param options An optional object that specifies characteristics about the event listener.
+ */
 export function useEventListener<
 	TElement extends HTMLElement,
 	TEvent extends keyof HTMLElementEventMap,
@@ -26,6 +40,13 @@ export function useEventListener<
 	options?: boolean | AddEventListenerOptions
 ): void;
 
+/**
+ * Adds an event listener to the specified target element for the given event(s), and returns a function to remove it.
+ * @param target The target element to add the event listener to.
+ * @param event The event(s) to listen for.
+ * @param handler The function to be called when the event is triggered.
+ * @param options An optional object that specifies characteristics about the event listener.
+ */
 export function useEventListener(
 	target: MaybeBoxOrGetter<EventTarget | null | undefined>,
 	event: string | string[],
@@ -38,7 +59,7 @@ export function useEventListener(
 	event: string | string[],
 	handler: EventListenerOrEventListenerObject,
 	options?: boolean | AddEventListenerOptions
-) {
+): void {
 	const target = box.from(_target);
 
 	$effect(() => {

--- a/packages/runed/src/lib/internal/utils/event.ts
+++ b/packages/runed/src/lib/internal/utils/event.ts
@@ -2,57 +2,55 @@
  *  Overloaded function signatures for addEventListener
  */
 export function addEventListener<TEvent extends keyof WindowEventMap>(
-	target: Window,
-	event: TEvent,
-	handler: (this: Window, event: WindowEventMap[TEvent]) => unknown,
-	options?: boolean | AddEventListenerOptions
+    target: Window,
+    event: TEvent,
+    handler: (this: Window, event: WindowEventMap[TEvent]) => unknown,
+    options?: boolean | AddEventListenerOptions
 ): VoidFunction;
 
 export function addEventListener<TEvent extends keyof DocumentEventMap>(
-	target: Document,
-	event: TEvent,
-	handler: (this: Document, event: DocumentEventMap[TEvent]) => unknown,
-	options?: boolean | AddEventListenerOptions
+    target: Document,
+    event: TEvent,
+    handler: (this: Document, event: DocumentEventMap[TEvent]) => unknown,
+    options?: boolean | AddEventListenerOptions
 ): VoidFunction;
 
 export function addEventListener<
-	TElement extends HTMLElement,
-	TEvent extends keyof HTMLElementEventMap,
+    TElement extends HTMLElement,
+    TEvent extends keyof HTMLElementEventMap,
 >(
-	target: TElement,
-	event: TEvent,
-	handler: (this: TElement, event: HTMLElementEventMap[TEvent]) => unknown,
-	options?: boolean | AddEventListenerOptions
+    target: TElement,
+    event: TEvent,
+    handler: (this: TElement, event: HTMLElementEventMap[TEvent]) => unknown,
+    options?: boolean | AddEventListenerOptions
 ): VoidFunction;
 
 export function addEventListener(
-	target: EventTarget,
-	event: string,
-	handler: EventListenerOrEventListenerObject,
-	options?: boolean | AddEventListenerOptions
+    target: EventTarget,
+    event: string,
+    handler: EventListenerOrEventListenerObject,
+    options?: boolean | AddEventListenerOptions
 ): VoidFunction;
 
 /**
- * Adds an event listener to the specified target element(s) for the given event(s), and returns a function to remove it.
- * @param target The target element(s) to add the event listener to.
- * @param event The event(s) to listen for.
+ * Adds an event listener to the specified target element for the given event, and returns a function to remove it.
+ * @param target The target element to add the event listener to.
+ * @param event The event to listen for.
  * @param handler The function to be called when the event is triggered.
  * @param options An optional object that specifies characteristics about the event listener.
- * @returns A function that removes the event listener from the target element(s).
+ * @returns A function that removes the event listener from the target element.
  */
 export function addEventListener(
-	target: Window | Document | EventTarget,
-	event: string | string[],
-	handler: EventListenerOrEventListenerObject,
-	options?: boolean | AddEventListenerOptions
+    target: EventTarget,
+    event: string,
+    handler: EventListenerOrEventListenerObject,
+    options?: boolean | AddEventListenerOptions
 ) {
-	const events = Array.isArray(event) ? event : [event];
+    // Add the event listener to each specified event for the target element.
+    target.addEventListener(event, handler, options);
 
-	// Add the event listener to each specified event for the target element(s).
-	events.forEach((_event) => target.addEventListener(_event, handler, options));
-
-	// Return a function that removes the event listener from the target element(s).
-	return () => {
-		events.forEach((_event) => target.removeEventListener(_event, handler, options));
-	};
+    // Return a function that removes the event listener from the target element(s).
+    return () => {
+        target.removeEventListener(event, handler, options);
+    };
 }

--- a/packages/runed/src/lib/internal/utils/event.ts
+++ b/packages/runed/src/lib/internal/utils/event.ts
@@ -2,34 +2,34 @@
  *  Overloaded function signatures for addEventListener
  */
 export function addEventListener<TEvent extends keyof WindowEventMap>(
-    target: Window,
-    event: TEvent,
-    handler: (this: Window, event: WindowEventMap[TEvent]) => unknown,
-    options?: boolean | AddEventListenerOptions
+	target: Window,
+	event: TEvent,
+	handler: (this: Window, event: WindowEventMap[TEvent]) => unknown,
+	options?: boolean | AddEventListenerOptions
 ): VoidFunction;
 
 export function addEventListener<TEvent extends keyof DocumentEventMap>(
-    target: Document,
-    event: TEvent,
-    handler: (this: Document, event: DocumentEventMap[TEvent]) => unknown,
-    options?: boolean | AddEventListenerOptions
+	target: Document,
+	event: TEvent,
+	handler: (this: Document, event: DocumentEventMap[TEvent]) => unknown,
+	options?: boolean | AddEventListenerOptions
 ): VoidFunction;
 
 export function addEventListener<
-    TElement extends HTMLElement,
-    TEvent extends keyof HTMLElementEventMap,
+	TElement extends HTMLElement,
+	TEvent extends keyof HTMLElementEventMap,
 >(
-    target: TElement,
-    event: TEvent,
-    handler: (this: TElement, event: HTMLElementEventMap[TEvent]) => unknown,
-    options?: boolean | AddEventListenerOptions
+	target: TElement,
+	event: TEvent,
+	handler: (this: TElement, event: HTMLElementEventMap[TEvent]) => unknown,
+	options?: boolean | AddEventListenerOptions
 ): VoidFunction;
 
 export function addEventListener(
-    target: EventTarget,
-    event: string,
-    handler: EventListenerOrEventListenerObject,
-    options?: boolean | AddEventListenerOptions
+	target: EventTarget,
+	event: string,
+	handler: EventListenerOrEventListenerObject,
+	options?: boolean | AddEventListenerOptions
 ): VoidFunction;
 
 /**
@@ -41,16 +41,16 @@ export function addEventListener(
  * @returns A function that removes the event listener from the target element.
  */
 export function addEventListener(
-    target: EventTarget,
-    event: string,
-    handler: EventListenerOrEventListenerObject,
-    options?: boolean | AddEventListenerOptions
+	target: EventTarget,
+	event: string,
+	handler: EventListenerOrEventListenerObject,
+	options?: boolean | AddEventListenerOptions
 ) {
-    // Add the event listener to each specified event for the target element.
-    target.addEventListener(event, handler, options);
+	// Add the event listener to each specified event for the target element.
+	target.addEventListener(event, handler, options);
 
-    // Return a function that removes the event listener from the target element(s).
-    return () => {
-        target.removeEventListener(event, handler, options);
-    };
+	// Return a function that removes the event listener from the target element(s).
+	return () => {
+		target.removeEventListener(event, handler, options);
+	};
 }

--- a/packages/runed/src/lib/internal/utils/event.ts
+++ b/packages/runed/src/lib/internal/utils/event.ts
@@ -66,7 +66,7 @@ export function addEventListener(
 	event: string | string[],
 	handler: EventListenerOrEventListenerObject,
 	options?: boolean | AddEventListenerOptions
-) {
+): VoidFunction {
 	const events = Array.isArray(event) ? event : [event];
 
 	for (const event of events) {

--- a/packages/runed/src/lib/internal/utils/event.ts
+++ b/packages/runed/src/lib/internal/utils/event.ts
@@ -1,56 +1,81 @@
 /**
- *  Overloaded function signatures for addEventListener
+ * Adds an event listener to the specified target element for the given event(s), and returns a function to remove it.
+ * @param target The target element to add the event listener to.
+ * @param event The event(s) to listen for.
+ * @param handler The function to be called when the event is triggered.
+ * @param options An optional object that specifies characteristics about the event listener.
+ * @returns A function that removes the event listener(s) from the target element.
  */
 export function addEventListener<TEvent extends keyof WindowEventMap>(
 	target: Window,
-	event: TEvent,
+	event: TEvent | TEvent[],
 	handler: (this: Window, event: WindowEventMap[TEvent]) => unknown,
 	options?: boolean | AddEventListenerOptions
 ): VoidFunction;
 
+/**
+ * Adds an event listener to the specified target element for the given event(s), and returns a function to remove it.
+ * @param target The target element to add the event listener to.
+ * @param event The event(s) to listen for.
+ * @param handler The function to be called when the event is triggered.
+ * @param options An optional object that specifies characteristics about the event listener.
+ * @returns A function that removes the event listener(s) from the target element.
+ */
 export function addEventListener<TEvent extends keyof DocumentEventMap>(
 	target: Document,
-	event: TEvent,
+	event: TEvent | TEvent[],
 	handler: (this: Document, event: DocumentEventMap[TEvent]) => unknown,
 	options?: boolean | AddEventListenerOptions
 ): VoidFunction;
 
+/**
+ * Adds an event listener to the specified target element for the given event(s), and returns a function to remove it.
+ * @param target The target element to add the event listener to.
+ * @param event The event(s) to listen for.
+ * @param handler The function to be called when the event is triggered.
+ * @param options An optional object that specifies characteristics about the event listener.
+ * @returns A function that removes the event listener(s) from the target element.
+ */
 export function addEventListener<
 	TElement extends HTMLElement,
 	TEvent extends keyof HTMLElementEventMap,
 >(
 	target: TElement,
-	event: TEvent,
+	event: TEvent | TEvent[],
 	handler: (this: TElement, event: HTMLElementEventMap[TEvent]) => unknown,
 	options?: boolean | AddEventListenerOptions
 ): VoidFunction;
 
+/**
+ * Adds an event listener to the specified target element for the given event(s), and returns a function to remove it.
+ * @param target The target element to add the event listener to.
+ * @param event The event(s) to listen for.
+ * @param handler The function to be called when the event is triggered.
+ * @param options An optional object that specifies characteristics about the event listener.
+ * @returns A function that removes the event listener(s) from the target element.
+ */
 export function addEventListener(
 	target: EventTarget,
-	event: string,
+	event: string | string[],
 	handler: EventListenerOrEventListenerObject,
 	options?: boolean | AddEventListenerOptions
 ): VoidFunction;
 
-/**
- * Adds an event listener to the specified target element for the given event, and returns a function to remove it.
- * @param target The target element to add the event listener to.
- * @param event The event to listen for.
- * @param handler The function to be called when the event is triggered.
- * @param options An optional object that specifies characteristics about the event listener.
- * @returns A function that removes the event listener from the target element.
- */
 export function addEventListener(
 	target: EventTarget,
-	event: string,
+	event: string | string[],
 	handler: EventListenerOrEventListenerObject,
 	options?: boolean | AddEventListenerOptions
 ) {
-	// Add the event listener to each specified event for the target element.
-	target.addEventListener(event, handler, options);
+	const events = Array.isArray(event) ? event : [event];
 
-	// Return a function that removes the event listener from the target element(s).
+	for (const event of events) {
+		target.addEventListener(event, handler, options);
+	}
+
 	return () => {
-		target.removeEventListener(event, handler, options);
+		for (const event of events) {
+			target.removeEventListener(event, handler, options);
+		}
 	};
 }


### PR DESCRIPTION
The overloads for `addEventListener` define the `event` parameter as a `string`, but the implementation define it as `string | string[]`.

This PR removes the unnecessary code needed to support `string[]`.