### PR TITLE
Fix Watcher

### DIFF
--- a/packages/runed/src/lib/functions/watch/watch.svelte.ts
+++ b/packages/runed/src/lib/functions/watch/watch.svelte.ts
@@ -64,8 +64,8 @@ function runWatcher<T>(
 				// values instead of `undefined` to allow destructuring.
 				//
 				// watch([a, b], ([a, b], [prevA, prevB]) => { ... });
-				if (previousValues === undefined && Array.isArray(values)) {
-					previousValues = Array(values.length).fill(undefined);
+				if (previousValues === undefined && Array.isArray(sources)) {
+					previousValues = Array(sources.length).fill(undefined);
 				}
 
 				cleanupEffect = untrack(() => effect(values, previousValues));

--- a/packages/runed/src/lib/functions/watch/watch.test.svelte.ts
+++ b/packages/runed/src/lib/functions/watch/watch.test.svelte.ts
@@ -5,7 +5,7 @@ import { testWithEffect } from "$lib/test/util.svelte.js";
 import { sleep } from "$lib/internal/utils/sleep.js";
 
 describe("watch", () => {
-	testWithEffect("watchers only tracks their dependencies", async () => {
+	testWithEffect("watchers only track their dependencies", async () => {
 		let count = $state(0);
 		let runs = $state(0);
 
@@ -106,7 +106,7 @@ describe("watch", () => {
 		expect(runs).toBe(1);
 	});
 
-	testWithEffect("watchers with an array getter returns `undefined` as the previous value", () => {
+	testWithEffect("watchers with an array getter pass `undefined` as the previous value", () => {
 		watch(
 			() => [1, 2, 3],
 			(_, previous) => {

--- a/packages/runed/src/lib/functions/watch/watch.test.svelte.ts
+++ b/packages/runed/src/lib/functions/watch/watch.test.svelte.ts
@@ -105,4 +105,13 @@ describe("watch", () => {
 
 		expect(runs).toBe(1);
 	});
+
+	testWithEffect("watchers with an array getter returns `undefined` as the previous value", () => {
+		watch(
+			() => [1, 2, 3],
+			(_, previous) => {
+				expect(previous).toBe(undefined);
+			}
+		);
+	});
 });


### PR DESCRIPTION
This PR fixes a minor bug with watchers that receive an array getter.
```ts
watch(
	() => [1, 2, 3],
	(value, previous) => {
		// ^ number[] | undefined
		// but this is actually an array of undefined values.
	},
)
```