### PR TITLE
Explicit Return Types

### DIFF
--- a/packages/runed/src/lib/internal/types.ts
+++ b/packages/runed/src/lib/internal/types.ts
@@ -1,6 +1,3 @@
-// eslint-disable-next-line ts/no-explicit-any
-export type FunctionArgs<Args extends any[] = any[], Return = void> = (...args: Args) => Return;
-
 export type Getter<T> = () => T;
 export type MaybeGetter<T> = T | Getter<T>;
 export type Setter<T> = (value: T) => void;

--- a/packages/runed/src/lib/internal/utils/array.ts
+++ b/packages/runed/src/lib/internal/utils/array.ts
@@ -1,9 +1,7 @@
 /**
- * Get nth item of Array. Negative for backward
+ * Get the nth item of an array. Negative for backward.
  */
-export function at(array: readonly [], index: number): undefined;
-export function at<T>(array: readonly T[], index: number): T;
-export function at<T>(array: readonly T[] | [], index: number): T | undefined {
+export function at<T>(array: readonly T[], index: number): T | undefined {
 	const len = array.length;
 	if (!len) return undefined;
 
@@ -12,6 +10,9 @@ export function at<T>(array: readonly T[] | [], index: number): T | undefined {
 	return array[index];
 }
 
+/**
+ * Get the last item of an array.
+ */
 export function last<T>(array: readonly T[]): T | undefined {
 	return array[array.length - 1];
 }

--- a/packages/runed/src/lib/internal/utils/browser.ts
+++ b/packages/runed/src/lib/internal/utils/browser.ts
@@ -1,3 +1,3 @@
-export function isBrowser() {
+export function isBrowser(): boolean {
 	return typeof document !== "undefined";
 }

--- a/packages/runed/src/lib/internal/utils/defer.ts
+++ b/packages/runed/src/lib/internal/utils/defer.ts
@@ -1,0 +1,17 @@
+export type Deferred<T> = {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+	reject: (reason: unknown) => void;
+};
+
+export function defer<T>(): Deferred<T> {
+	let resolve: (value: T) => void;
+	let reject: (reason: unknown) => void;
+
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+
+	return { promise, resolve: resolve!, reject: reject! };
+}

--- a/packages/runed/src/lib/internal/utils/sleep.ts
+++ b/packages/runed/src/lib/internal/utils/sleep.ts
@@ -1,3 +1,3 @@
-export async function sleep(ms: number) {
+export async function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/packages/runed/src/lib/test/util.svelte.ts
+++ b/packages/runed/src/lib/test/util.svelte.ts
@@ -1,6 +1,6 @@
 import { test } from "vitest";
 
-export function testWithEffect(name: string, fn: () => void | Promise<void>) {
+export function testWithEffect(name: string, fn: () => void | Promise<void>): void {
 	test(name, async () => {
 		let promise: void | Promise<void>;
 		const cleanup = $effect.root(() => {

--- a/packages/runed/src/lib/utilities/Debounced/Debounced.svelte.ts
+++ b/packages/runed/src/lib/utilities/Debounced/Debounced.svelte.ts
@@ -1,5 +1,4 @@
 import { useDebounce } from "../useDebounce/useDebounce.svelte.js";
-import { watch } from "../watch/watch.svelte.js";
 import type { Getter, MaybeGetter } from "$lib/internal/types.js";
 
 /**
@@ -7,24 +6,23 @@ import type { Getter, MaybeGetter } from "$lib/internal/types.js";
  *
  * @export
  * @class Debounced
- * @typedef {Debounced}
  */
 export class Debounced<T> {
-	#current = $state();
+	#current = $state() as T;
 
 	constructor(getter: Getter<T>, wait: MaybeGetter<number> = 250) {
 		this.#current = getter(); // immediately set the initial value
 
-		const callback = useDebounce(() => {
-			this.#current = getter();
+		const setCurrent = useDebounce((value: T) => {
+			this.#current = value;
 		}, wait);
 
-		watch(getter, () => {
-			callback();
+		$effect(() => {
+			setCurrent(getter());
 		});
 	}
 
-	get current() {
+	get current(): T {
 		return this.#current;
 	}
 }

--- a/packages/runed/src/lib/utilities/ElementSize/ElementSize.svelte.ts
+++ b/packages/runed/src/lib/utilities/ElementSize/ElementSize.svelte.ts
@@ -21,19 +21,14 @@ export type ElementSizeOptions = {
  * @see {@link https://runed.dev/docs/utilities/use-element-size}
  */
 export class ElementSize {
-	#size = $state({
-		width: 0,
-		height: 0,
-	});
+	#width: number = $state(0);
+	#height: number = $state(0);
 
-	constructor(
-		node: MaybeGetter<HTMLElement | undefined>,
-		options: ElementSizeOptions = { box: "border-box" }
-	) {
-		this.#size = {
-			width: options.initialSize?.width ?? 0,
-			height: options.initialSize?.height ?? 0,
-		};
+	constructor(node: MaybeGetter<Element | undefined>, options: ElementSizeOptions = {}) {
+		const { initialSize, box = "border-box" } = options;
+
+		this.#width = initialSize?.width ?? 0;
+		this.#height = initialSize?.height ?? 0;
 
 		$effect(() => {
 			const node$ = get(node);
@@ -41,11 +36,10 @@ export class ElementSize {
 
 			const observer = new ResizeObserver((entries) => {
 				for (const entry of entries) {
-					const boxSize =
-						options.box === "content-box" ? entry.contentBoxSize : entry.borderBoxSize;
+					const boxSize = box === "content-box" ? entry.contentBoxSize : entry.borderBoxSize;
 					const boxSizeArr = Array.isArray(boxSize) ? boxSize : [boxSize];
-					this.#size.width = boxSizeArr.reduce((acc, size) => Math.max(acc, size.inlineSize), 0);
-					this.#size.height = boxSizeArr.reduce((acc, size) => Math.max(acc, size.blockSize), 0);
+					this.#width = boxSizeArr.reduce((acc, size) => Math.max(acc, size.inlineSize), 0);
+					this.#height = boxSizeArr.reduce((acc, size) => Math.max(acc, size.blockSize), 0);
 				}
 			});
 			observer.observe(node$);
@@ -56,11 +50,11 @@ export class ElementSize {
 		});
 	}
 
-	get width() {
-		return this.#size.width;
+	get width(): number {
+		return this.#width;
 	}
 
-	get height() {
-		return this.#size.height;
+	get height(): number {
+		return this.#height;
 	}
 }

--- a/packages/runed/src/lib/utilities/IsMounted/IsMounted.svelte.ts
+++ b/packages/runed/src/lib/utilities/IsMounted/IsMounted.svelte.ts
@@ -5,19 +5,19 @@
  * @see {@link https://runed.dev/docs/utilities/use-mounted}
  */
 export class IsMounted {
-	#isMounted: boolean = $state(false);
+	#current: boolean = $state(false);
 
 	constructor() {
 		$effect(() => {
-			this.#isMounted = true;
+			this.#current = true;
 
 			return () => {
-				this.#isMounted = false;
+				this.#current = false;
 			};
 		});
 	}
 
 	get current(): boolean {
-		return this.#isMounted;
+		return this.#current;
 	}
 }

--- a/packages/runed/src/lib/utilities/IsMounted/IsMounted.svelte.ts
+++ b/packages/runed/src/lib/utilities/IsMounted/IsMounted.svelte.ts
@@ -1,5 +1,3 @@
-import { untrack } from "svelte";
-
 /**
  * Returns an object with the mounted state of the component
  * that invokes this function.
@@ -7,11 +5,11 @@ import { untrack } from "svelte";
  * @see {@link https://runed.dev/docs/utilities/use-mounted}
  */
 export class IsMounted {
-	#isMounted = $state(false);
+	#isMounted: boolean = $state(false);
 
 	constructor() {
 		$effect(() => {
-			untrack(() => (this.#isMounted = true));
+			this.#isMounted = true;
 
 			return () => {
 				this.#isMounted = false;
@@ -19,7 +17,7 @@ export class IsMounted {
 		});
 	}
 
-	get current() {
+	get current(): boolean {
 		return this.#isMounted;
 	}
 }

--- a/packages/runed/src/lib/utilities/IsSupported/IsSupported.ts
+++ b/packages/runed/src/lib/utilities/IsSupported/IsSupported.ts
@@ -6,7 +6,7 @@
  * @see {@link https://runed.dev/docs/utilities/use-supported}
  */
 export class IsSupported {
-	#current = $state(false);
+	#current: boolean = $state(false);
 
 	constructor(predicate: () => boolean) {
 		$effect(() => {
@@ -14,7 +14,7 @@ export class IsSupported {
 		});
 	}
 
-	get current() {
+	get current(): boolean {
 		return this.#current;
 	}
 }

--- a/packages/runed/src/lib/utilities/Previous/Previous.svelte.ts
+++ b/packages/runed/src/lib/utilities/Previous/Previous.svelte.ts
@@ -6,7 +6,7 @@ import type { Getter } from "$lib/internal/types.js";
  * @see {@link https://runed.dev/docs/utilities/use-previous}
  */
 export class Previous<T> {
-	#previous = $state<T | undefined>(undefined);
+	#previous: T | undefined = $state();
 	#curr?: T;
 
 	constructor(getter: Getter<T>) {
@@ -16,7 +16,7 @@ export class Previous<T> {
 		});
 	}
 
-	get current() {
+	get current(): T | undefined {
 		return this.#previous;
 	}
 }

--- a/packages/runed/src/lib/utilities/extract/extract.test.ts
+++ b/packages/runed/src/lib/utilities/extract/extract.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { extract } from "./extract.js";
+
+describe("extract", () => {
+	it("extract replaces undefined with the default value", () => {
+		expect(extract(undefined, "default")).toBe("default");
+		expect(extract<string | undefined>(() => undefined, "default")).toBe("default");
+	});
+
+	it("extract does not replace null with the default value", () => {
+		expect(extract(null, "default")).toBe(null);
+		expect(extract(() => null, "default")).toBe(null);
+	});
+
+	it("extract returns the value back without a default value", () => {
+		expect(extract("value")).toBe("value");
+		expect(extract(() => "value")).toBe("value");
+	});
+});

--- a/packages/runed/src/lib/utilities/extract/extract.ts
+++ b/packages/runed/src/lib/utilities/extract/extract.ts
@@ -1,15 +1,20 @@
-import type { Getter, MaybeGetter } from "$lib/internal/types.js";
-import { isFunction } from "$lib/internal/utils/is.js";
+import type { MaybeGetter } from "$lib/internal/types.js";
+import { get } from "$lib/internal/utils/get.js";
 
 /**
  * Extracts the value from a getter or a value.
- * Optionally, a default value can be provided.
  */
-export function extract<T>(value: MaybeGetter<T>, defaultValue?: T): T {
-	if (isFunction(value)) {
-		const getter = value as Getter<T>;
-		return getter() ?? defaultValue ?? getter();
-	}
+export function extract<T>(value: MaybeGetter<T>): T;
 
-	return value ?? defaultValue ?? value;
+/**
+ * Extracts the value from a getter or a value, replacing `undefined` with the default value.
+ */
+export function extract<T>(value: MaybeGetter<T | undefined>, defaultValue: T): T;
+
+export function extract<T>(value: MaybeGetter<T>, defaultValue?: T): T | undefined {
+	const result = get(value);
+	if (result === undefined) {
+		return defaultValue;
+	}
+	return result;
 }

--- a/packages/runed/src/lib/utilities/useDebounce/useDebounce.svelte.ts
+++ b/packages/runed/src/lib/utilities/useDebounce/useDebounce.svelte.ts
@@ -17,7 +17,7 @@ import { type Deferred, defer } from "$lib/internal/utils/defer.js";
  *
  * @see {@link https://runed.dev/docs/utilities/use-debounce}
  */
-export function useDebounce<Args extends unknown[], Return>(
+export function useDebounce<Args extends unknown[], Return = void>(
 	callback: (...args: Args) => Return,
 	wait: MaybeGetter<number> = 250
 ): (this: unknown, ...args: Args) => Promise<Return> {

--- a/packages/runed/src/lib/utilities/useDebounce/useDebounce.svelte.ts
+++ b/packages/runed/src/lib/utilities/useDebounce/useDebounce.svelte.ts
@@ -1,6 +1,6 @@
-import { extract } from "../extract/extract.js";
 import type { MaybeGetter } from "$lib/internal/types.js";
 import { type Deferred, defer } from "$lib/internal/utils/defer.js";
+import { get } from "$lib/internal/utils/get.js";
 
 /**
  * Function that takes a callback, and returns a debounced version of it.
@@ -44,7 +44,7 @@ export function useDebounce<Args extends unknown[], Return = void>(
 				timeout = undefined;
 				deferred = undefined;
 			}
-		}, extract(wait));
+		}, get(wait));
 
 		return promise;
 	};

--- a/packages/runed/src/lib/utilities/useEventListener/useEventListener.svelte.ts
+++ b/packages/runed/src/lib/utilities/useEventListener/useEventListener.svelte.ts
@@ -1,6 +1,6 @@
-import { extract } from "../extract/extract.js";
 import type { MaybeGetter } from "$lib/internal/types.js";
 import { addEventListener } from "$lib/internal/utils/event.js";
+import { get } from "$lib/internal/utils/get.js";
 
 /**
  * Adds an event listener to the specified target element for the given event(s), and returns a function to remove it.
@@ -61,14 +61,14 @@ export function useEventListener(
 ): void;
 
 export function useEventListener(
-	_target: MaybeGetter<EventTarget | null | undefined>,
+	target: MaybeGetter<EventTarget | null | undefined>,
 	event: string | string[],
 	handler: EventListenerOrEventListenerObject,
 	options?: boolean | AddEventListenerOptions
 ): void {
 	$effect(() => {
-		const target = extract(_target);
-		if (target === undefined || target === null) return;
-		return addEventListener(target, event, handler, options);
+		const target$ = get(target);
+		if (target$ === undefined || target$ === null) return;
+		return addEventListener(target$, event, handler, options);
 	});
 }

--- a/packages/runed/src/lib/utilities/watch/watch.svelte.ts
+++ b/packages/runed/src/lib/utilities/watch/watch.svelte.ts
@@ -2,7 +2,7 @@ import { untrack } from "svelte";
 import { isFunction } from "$lib/internal/utils/is.js";
 import type { Getter } from "$lib/internal/types.js";
 
-function runEffect(flush: "pre" | "post", effect: () => void | (() => void)) {
+function runEffect(flush: "pre" | "post", effect: () => void | (() => void)): void {
 	switch (flush) {
 		case "pre": {
 			$effect.pre(effect);
@@ -38,7 +38,7 @@ function runWatcher<T>(
 	effect: (value: T, previousValue: PreviousValue<T>) => void | (() => void),
 	flush: "pre" | "post",
 	options: WatchOptions = {}
-) {
+): void {
 	const { lazy = false, once = false } = options;
 
 	const cleanupRoot = $effect.root(() => {

--- a/packages/runed/src/lib/utilities/watch/watch.svelte.ts
+++ b/packages/runed/src/lib/utilities/watch/watch.svelte.ts
@@ -96,9 +96,9 @@ export function watch<T>(
 }
 
 watch.pre = function <T>(
-	sources: Getter<T>,
+	source: Getter<T>,
 	effect: (value: T, previousValue: PreviousValue<T>) => void | (() => void),
 	options?: WatchOptions
 ): void {
-	runWatcher(sources, effect, "pre", options);
+	runWatcher(source, effect, "pre", options);
 };


### PR DESCRIPTION
- Add explicit return types to our utilities to avoid unexpected types or behavior.
- Some minor refactoring.
- Fixed `extract` helper behavior with `null`.