### PR TITLE
feat: add MediaQuery utility

### DIFF
--- a/.changeset/new-bears-speak.md
+++ b/.changeset/new-bears-speak.md
@@ -1,0 +1,5 @@
+---
+"runed": minor
+---
+
+feat: add MediaQuery utility

--- a/packages/runed/src/lib/utilities/MediaQuery/MediaQuery.svelte.ts
+++ b/packages/runed/src/lib/utilities/MediaQuery/MediaQuery.svelte.ts
@@ -1,0 +1,52 @@
+/**
+ * Take a media query (or a function that returns one if you want reactivity)
+ * as input and you can check if it currently matches doing `instance.match`
+ *
+ * @see {@link https://runed.dev/docs/utilities/media-query}
+ *
+ * @example
+ * ```ts
+ * const screen = new MediaQuery("(min-width: 640px)");
+ *
+ * $effect(()=>{
+ * 	if(screen.match){
+ * 		console.log("The screen is less than 640px");
+ * 	}
+ * });
+ * ```
+ * 
+ * @example
+ * ```ts
+ * let media = $state("(min-width: 640px)");
+ * const screen = new MediaQuery(()=> media);
+ *
+ * $effect(()=>{
+ * 	if(screen.match){
+ * 		console.log(`Media query ${media} is ${screen.match}`);
+ * 	}
+ * });
+ * 
+ * media = "(min-width: 320px)";
+ * ```
+
+ */
+export class MediaQuery {
+	match = $state<boolean | undefined>(undefined);
+
+	constructor(query: string | (() => string)) {
+		$effect(() => {
+			const result = window.matchMedia(typeof query === "function" ? query() : query);
+
+			this.match = result.matches;
+
+			const listener = (changed: MediaQueryListEvent) => {
+				this.match = changed.matches;
+			};
+
+			result.addEventListener("change", listener);
+			return () => {
+				result.removeEventListener("change", listener);
+			};
+		});
+	}
+}

--- a/packages/runed/src/lib/utilities/MediaQuery/index.ts
+++ b/packages/runed/src/lib/utilities/MediaQuery/index.ts
@@ -1,0 +1,1 @@
+export { MediaQuery } from "./MediaQuery.svelte.js";

--- a/packages/runed/src/lib/utilities/index.ts
+++ b/packages/runed/src/lib/utilities/index.ts
@@ -10,3 +10,4 @@ export * from "./watch/index.js";
 export * from "./Readable/index.js";
 export * from "./Debounced/index.js";
 export * from "./PressedKeys/index.js";
+export * from "./MediaQuery/index.js";

--- a/sites/docs/content/utilities/media-query.md
+++ b/sites/docs/content/utilities/media-query.md
@@ -1,0 +1,52 @@
+---
+title: MediaQuery
+description:
+  Take a media query (or a function that returns one if you want reactivity) as input and you can
+  check if it currently matches doing `instance.match`
+category: New
+---
+
+<script>
+import Demo from '$lib/components/demos/media-query.svelte';
+</script>
+
+## Demo
+
+<Demo />
+
+## Usage
+
+The simplest way of using this utility is just by passing a string with a valid media query.
+
+```svelte
+<script>
+	import { MediaQuery } from "runed";
+
+	const screen = new MediaQuery("(min-width: 640px)");
+</script>
+
+{#if screen.match}
+	Your screen is less than 640px
+{:else}
+	Your screen is more than 640px
+{/if}
+```
+
+but if you need you can also pass a function that returns a string and use state values for the
+media query
+
+```svelte
+<script lang="ts">
+	import { MediaQuery } from "runed";
+
+	let media = $state("(min-width: 640px)");
+	const query = new MediaQuery(() => media);
+</script>
+
+Media query {media} is currently {screen.match}
+
+<select bind:value={media}>
+	<option value="(min-width: 640px)">640px</option>
+	<option value="(min-width: 320px)">320px</option>
+</select>
+```

--- a/sites/docs/src/lib/components/demos/media-query.svelte
+++ b/sites/docs/src/lib/components/demos/media-query.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { MediaQuery } from "runed";
+
+	let media = $state("(min-width: 640px)");
+	const query = new MediaQuery(() => media);
+</script>
+
+<label>
+	Current media query:
+	<select bind:value={media}>
+		<option value="(min-width: 640px)">(min-width: 640px)</option>
+		<option value="(min-width: 320px)">(min-width: 320px)</option>
+		<option value="(min-width: 1080px)">(min-width: 1080px)</option>
+		<option value="(prefers-color-scheme: dark)">(prefers-color-scheme: dark)</option>
+		<option value="(prefers-color-scheme: light)">(prefers-color-scheme: light)</option>
+	</select>
+</label>
+<p>
+	The result of the media query <code>{media}</code> is {query.match}
+</p>


### PR DESCRIPTION
This adds a `MediaQuery` utility where you can pass a media query and get back true or false in case it matches (with reactivity).

You need to specifically pass the media query like this "(media-query-here)" so i was wondering if a warn in case the parentheses are not there could be a good thing. Maybe even add them automatically if not presents.

WDYT?

I did not add any test because for what i was able to see JSDom doesn't have a way to check media queries. I could mock that but i don't know if that's really useful.

Also also, i just created an effect in the constructor...this means it will likely fail if the instance is created in a `.svelte.ts` file. One possible way out of this could be to try to create the effect, if it fails wrap everything in `$effect.root` and expose a cleanup function that users need to call in the onDestroy by themselves...but i also think there should be a standard way for every utility.