### PR TITLE
feat: update `watch`

### DIFF
--- a/.changeset/quick-foxes-end.md
+++ b/.changeset/quick-foxes-end.md
@@ -1,0 +1,5 @@
+---
+"runed": minor
+---
+
+update `watch` utility

--- a/packages/runed/src/lib/utilities/watch/index.ts
+++ b/packages/runed/src/lib/utilities/watch/index.ts
@@ -1,1 +1,1 @@
-export { watch, type WatchOptions } from "./watch.svelte.js";
+export * from "./watch.svelte.js";

--- a/packages/runed/src/lib/utilities/watch/watch.test.svelte.ts
+++ b/packages/runed/src/lib/utilities/watch/watch.test.svelte.ts
@@ -57,7 +57,7 @@ describe("watch", () => {
 		}
 	);
 
-	testWithEffect("lazy watchers correctly pass the initial value as the previous value", () => {
+	testWithEffect("lazy watchers pass the initial value as the previous value", () => {
 		return new Promise((resolve) => {
 			let count = $state(0);
 
@@ -99,5 +99,25 @@ describe("watch", () => {
 		count++;
 		await sleep(0);
 		expect(runs).toBe(1);
+	});
+
+	testWithEffect("once watchers pass the initial value as the previous value", () => {
+		return new Promise((resolve) => {
+			let count = $state(0);
+
+			watchOnce(
+				() => count,
+				(count, prevCount) => {
+					expect(count).toBe(1);
+					expect(prevCount).toBe(0);
+					resolve();
+				}
+			);
+
+			// Wait for the watcher's initial run to determine its dependencies.
+			sleep(0).then(() => {
+				count = 1;
+			});
+		});
 	});
 });

--- a/packages/runed/src/lib/utilities/watch/watch.test.svelte.ts
+++ b/packages/runed/src/lib/utilities/watch/watch.test.svelte.ts
@@ -1,5 +1,5 @@
-import { describe, expect, vi } from "vitest";
-import { watch } from "./watch.svelte.js";
+import { describe, expect } from "vitest";
+import { watch, watchOnce } from "./watch.svelte.js";
 import { testWithEffect } from "$lib/test/util.svelte.js";
 import { sleep } from "$lib/internal/utils/sleep.js";
 
@@ -16,84 +16,88 @@ describe("watch", () => {
 		);
 
 		// Watchers run immediately by default
-		await vi.waitFor(() => {
-			expect(runs).toBe(1);
-		});
+		await sleep(0);
+		expect(runs).toBe(1);
 
 		count++;
-		await vi.waitFor(() => {
-			expect(runs).toBe(2);
-		});
+		await sleep(0);
+		expect(runs).toBe(2);
 	});
 
 	testWithEffect("watchers initially pass `undefined` as the previous value", () => {
-		const count = $state(0);
+		return new Promise<void>((resolve) => {
+			const count = $state(0);
 
-		watch(
-			() => count,
-			(count, prevCount) => {
-				expect(count).toBe(0);
-				expect(prevCount).toBe(undefined);
-			}
-		);
+			watch(
+				() => count,
+				(count, prevCount) => {
+					expect(count).toBe(0);
+					expect(prevCount).toBe(undefined);
+					resolve();
+				}
+			);
+		});
 	});
 
 	testWithEffect(
-		"watchers with an array initially pass an empty array as the previous value",
+		"watchers with an array of sources initially pass an empty array as the previous value",
 		() => {
-			const count = $state(1);
-			const doubled = $derived(count * 2);
+			return new Promise<void>((resolve) => {
+				const count = $state(1);
+				const doubled = $derived(count * 2);
 
-			watch(
-				() => [count, doubled],
-				([count, doubled], [prevCount, prevDoubled]) => {
+				watch([() => count, () => doubled], ([count, doubled], [prevCount, prevDoubled]) => {
 					expect(count).toBe(1);
 					expect(prevCount).toBe(undefined);
-
 					expect(doubled).toBe(2);
 					expect(prevDoubled).toBe(undefined);
-				}
-			);
+					resolve();
+				});
+			});
 		}
 	);
 
-	testWithEffect(
-		"lazy watchers correctly pass the initial value as the previous value",
-		async () => {
-			const count = $state(0);
+	testWithEffect("lazy watchers correctly pass the initial value as the previous value", () => {
+		return new Promise((resolve) => {
+			let count = $state(0);
 
 			watch(
 				() => count,
 				(count, prevCount) => {
 					expect(count).toBe(1);
 					expect(prevCount).toBe(0);
+					resolve();
 				},
 				{ lazy: true }
 			);
-		}
-	);
 
-	testWithEffect("watchers with `{ once: true }` only run once", async () => {
+			// Wait for the watcher's initial run to determine its dependencies.
+			sleep(0).then(() => {
+				count = 1;
+			});
+		});
+	});
+
+	testWithEffect("once watchers only run once", async () => {
 		let count = $state(0);
-
 		let runs = 0;
-		watch(
+
+		watchOnce(
 			() => count,
 			() => {
 				runs++;
-			},
-			{ once: true }
+			}
 		);
 
-		await vi.waitFor(() => {
-			expect(runs).toBe(1);
-		});
-
-		count++;
-
-		// Give the watcher a chance to rerun.
+		// Wait for the watcher's initial run to determine its dependencies.
 		await sleep(0);
 
+		count++;
+		await sleep(0);
+		expect(runs).toBe(1);
+
+		count++;
+		await sleep(0);
 		expect(runs).toBe(1);
 	});
 });


### PR DESCRIPTION
This PR changes two things about the `watch` helper.

1. Remove the `once: boolean` option in favor of a separate `watchOnce` function.
The default behavior for `watch` is to run immediately, unlike in Vue where it runs lazily when a dependency changes, so having `once: true` behave just like `onMount` by default makes no sense. As an added bonus, `watch` is now much simpler internally.

2. To watch for changes to multiple values, you pass an array of getters.
Previously, you would pass a getter to an array of state values, but this is kind of ambiguous. What if I want to watch for changes to a single state that happens to be an array?
```ts
let items = $state([]);
watch(() => items, (items, previousItems) => {
  // `previousItems` is an empty array, but it should be `undefined`!
});

// proposed change:
let a = $state();
let b = $state();
watch([() => a, () => b], ([a, b], [prevA, prevB]) => {...});
```