### PR TITLE
remove changesets from docs

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,5 +9,6 @@
   "linked": [],
   "access": "public",
   "baseBranch": "main",
-  "updateInternalDependencies": "patch"
+  "updateInternalDependencies": "patch",
+  "ignore": ["docs"]
 }

--- a/sites/docs/CHANGELOG.md
+++ b/sites/docs/CHANGELOG.md
@@ -1,7 +1,0 @@
-# docs
-
-## 0.0.1
-
-### Patch Changes
-
-- chore: fixed publishing issue ([#97](https://github.com/svecosystem/runed/pull/97))

--- a/sites/docs/package.json
+++ b/sites/docs/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "docs",
 	"description": "Docs for Runed",
-	"version": "0.0.1",
+	"version": "0.0.0",
 	"private": true,
 	"scripts": {
 		"dev": "concurrently \"pnpm:dev:content\" \"pnpm:dev:svelte\"",


### PR DESCRIPTION
undoing a failed attempt at redeploying docs site without cutting a new runed release