### PR TITLE
fix: Ensure watch() runs when object properties are mutated

### DIFF
--- a/.changeset/tough-news-drop.md
+++ b/.changeset/tough-news-drop.md
@@ -1,0 +1,5 @@
+---
+"runed": minor
+---
+
+Bug Fix: Ensure `watch()` fires on object property mutations

--- a/packages/runed/src/lib/utilities/watch/watch.svelte.ts
+++ b/packages/runed/src/lib/utilities/watch/watch.svelte.ts
@@ -44,10 +44,9 @@ function runWatcher<T>(
 		: undefined;
 
 	runEffect(flush, () => {
-		const sourcesSnapshot = $state.snapshot(sources);
-		const values = Array.isArray(sourcesSnapshot)
-			? sourcesSnapshot.map((source) => $state.snapshot(source()))
-			: sourcesSnapshot();
+		const values = Array.isArray(sources)
+			? sources.map((source) => $state.snapshot(source()))
+			: $state.snapshot(sources());
 
 		if (!active) {
 			active = true;

--- a/packages/runed/src/lib/utilities/watch/watch.svelte.ts
+++ b/packages/runed/src/lib/utilities/watch/watch.svelte.ts
@@ -44,7 +44,10 @@ function runWatcher<T>(
 		: undefined;
 
 	runEffect(flush, () => {
-		const values = Array.isArray(sources) ? sources.map((source) => source()) : sources();
+		const sourcesSnapshot = $state.snapshot(sources);
+		const values = Array.isArray(sourcesSnapshot)
+			? sourcesSnapshot.map((source) => $state.snapshot(source()))
+			: sourcesSnapshot();
 
 		if (!active) {
 			active = true;

--- a/packages/runed/src/lib/utilities/watch/watch.test.svelte.ts
+++ b/packages/runed/src/lib/utilities/watch/watch.test.svelte.ts
@@ -120,4 +120,26 @@ describe("watch", () => {
 			});
 		});
 	});
+
+	testWithEffect("watch is triggered when nested object properties are mutated", async () => {
+		let condition = $state({ name: "Bob" });
+		let runs = 0;
+
+		function toggleName() {
+			condition.name = condition.name === "Bob" ? "John" : "Bob";
+		}
+
+		watch([() => condition], () => {
+			runs++;
+		});
+
+		// Watch should run initially
+		await sleep(0);
+		expect(runs).toBe(1);
+
+		// Toggle name and check if watcher runs
+		toggleName();
+		await sleep(0);
+		expect(runs).toBe(2);
+	});
 });

--- a/packages/runed/src/lib/utilities/watch/watch.test.svelte.ts
+++ b/packages/runed/src/lib/utilities/watch/watch.test.svelte.ts
@@ -129,9 +129,12 @@ describe("watch", () => {
 			condition.name = condition.name === "Bob" ? "John" : "Bob";
 		}
 
-		watch([() => condition], () => {
-			runs++;
-		});
+		watch(
+			() => condition,
+			() => {
+				runs++;
+			}
+		);
 
 		// Watch should run initially
 		await sleep(0);


### PR DESCRIPTION
Ensure `watch()` runs when object properties are mutated

Closes #119