### PR TITLE
fix: avoid writing to state in media-query getter

### DIFF
--- a/.changeset/hot-feet-hang.md
+++ b/.changeset/hot-feet-hang.md
@@ -1,0 +1,5 @@
+---
+"runed": patch
+---
+
+fix: avoid writing to state in media-query getter

--- a/packages/runed/src/lib/utilities/MediaQuery/MediaQuery.svelte.ts
+++ b/packages/runed/src/lib/utilities/MediaQuery/MediaQuery.svelte.ts
@@ -1,7 +1,6 @@
-import { useEventListener } from "../useEventListener/useEventListener.svelte.js";
 import { extract } from "../extract/extract.js";
+import { useEventListener } from "../useEventListener/useEventListener.svelte.js";
 import type { MaybeGetter } from "$lib/internal/types.js";
-import { browser } from "$lib/internal/utils/browser.js";
 
 /**
  * Takes a media query as an input and listsens for changes to it,
@@ -47,8 +46,6 @@ export class MediaQuery {
 
 	get matches(): boolean | undefined {
 		if ($effect.tracking() && !this.#effectRegistered) {
-			this.#matches = this.#mediaQueryList.matches;
-
 			// If we are in an effect and this effect has not been registered yet
 			// we match the current value, register the listener and return match
 			$effect(() => {
@@ -62,11 +59,8 @@ export class MediaQuery {
 
 				return () => (this.#effectRegistered = false);
 			});
-		} else if (!$effect.tracking() && browser) {
-			// Otherwise, just match media to get the current value
-			this.#matches = this.#mediaQueryList.matches;
 		}
 
-		return this.#matches;
+		return this.#matches ?? this.#mediaQueryList.matches;
 	}
 }


### PR DESCRIPTION
This fixes a bug someone opened in the svelte repo but it was actually our (namely **my** lol) bad.

EDIT: oh they also reported here... Closes #121 

https://github.com/sveltejs/svelte/issues/12571#issuecomment-2248328612

We should avoid writing to state in the getter but we can just leave the state undefined and return the actual value from mediaQuery list (it will still be reactive from the moment we register the listener since we are still accessing the signal to check if it's undefined).

EDIT: i've also changed effectRegistered to a number to handle the case where multiple components that access the same instance of the class mount in the same tick.