### PR TITLE
/fix new term "raw" used in svelte@5.0.0-next.218 instead of "frozen"

### DIFF
--- a/packages/runed/src/lib/utilities/ElementRect/ElementRect.svelte.ts
+++ b/packages/runed/src/lib/utilities/ElementRect/ElementRect.svelte.ts
@@ -21,7 +21,7 @@ export type ElementRectOptions = {
  * @see {@link https://runed.dev/docs/utilities/element-size}
  */
 export class ElementRect {
-	#rect: Rect = $state.frozen({
+	#rect: Rect = $state.raw({
 		x: 0,
 		y: 0,
 		width: 0,


### PR DESCRIPTION
$state.frozen was replaced by $state.raw in Svelte 5.00-next.218.