### PR TITLE
fix: only listen for the 'storage' event if using 'local' storage

### DIFF
--- a/.changeset/two-pianos-beg.md
+++ b/.changeset/two-pianos-beg.md
@@ -1,0 +1,5 @@
+---
+"runed": patch
+---
+
+fix: `PersistedState` - only listen for the `'storage'` event if using `'local'` storage

--- a/packages/runed/src/lib/internal/utils/sleep.ts
+++ b/packages/runed/src/lib/internal/utils/sleep.ts
@@ -1,3 +1,3 @@
-export async function sleep(ms: number): Promise<void> {
+export async function sleep(ms = 0): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/packages/runed/src/lib/test/util.svelte.ts
+++ b/packages/runed/src/lib/test/util.svelte.ts
@@ -29,7 +29,3 @@ export function focus(node: HTMLElement | null | undefined) {
 		flushSync(() => node.focus());
 	}
 }
-
-export function delay(timeout = 0) {
-	return new Promise((resolve) => setTimeout(resolve, timeout));
-}

--- a/packages/runed/src/lib/test/util.svelte.ts
+++ b/packages/runed/src/lib/test/util.svelte.ts
@@ -29,3 +29,7 @@ export function focus(node: HTMLElement | null | undefined) {
 		flushSync(() => node.focus());
 	}
 }
+
+export function delay(timeout = 0) {
+	return new Promise((resolve) => setTimeout(resolve, timeout));
+}

--- a/packages/runed/src/lib/utilities/PersistedState/PersistedState.svelte.ts
+++ b/packages/runed/src/lib/utilities/PersistedState/PersistedState.svelte.ts
@@ -129,7 +129,7 @@ export class PersistedState<T> {
 
 		$effect(() => {
 			if (!syncTabs || storageType !== "local") return;
-			
+
 			return addEventListener(window, "storage", this.#handleStorageEvent.bind(this));
 		});
 	}

--- a/packages/runed/src/lib/utilities/PersistedState/PersistedState.svelte.ts
+++ b/packages/runed/src/lib/utilities/PersistedState/PersistedState.svelte.ts
@@ -128,7 +128,8 @@ export class PersistedState<T> {
 		});
 
 		$effect(() => {
-			if (!syncTabs) return;
+			if (!syncTabs || storageType !== "local") return;
+			
 			return addEventListener(window, "storage", this.#handleStorageEvent.bind(this));
 		});
 	}

--- a/packages/runed/src/lib/utilities/PersistedState/PersistedState.test.svelte.ts
+++ b/packages/runed/src/lib/utilities/PersistedState/PersistedState.test.svelte.ts
@@ -99,8 +99,15 @@ describe("PersistedState", () => {
 			async () => {
 				const persistedState = new PersistedState(key, initialValue, { syncTabs: false });
 				await delay();
-				localStorage.setItem(key, JSON.stringify("new-value"));
-				await delay();
+				const newValue = "new-value";
+				localStorage.setItem(key, JSON.stringify(newValue));
+				const event = new StorageEvent("storage", {
+					key,
+					oldValue: initialValue,
+					newValue: JSON.stringify(newValue),
+				});
+				window.dispatchEvent(event);
+					await delay();
 				expect(persistedState.current).toBe(initialValue);
 			}
 		);

--- a/packages/runed/src/lib/utilities/PersistedState/PersistedState.test.svelte.ts
+++ b/packages/runed/src/lib/utilities/PersistedState/PersistedState.test.svelte.ts
@@ -1,7 +1,7 @@
 import { describe, expect } from "vitest";
 
+import { delay, testWithEffect } from "$lib/test/util.svelte.js";
 import { PersistedState } from "./index.js";
-import { testWithEffect } from "$lib/test/util.svelte.js";
 
 const key = "test-key";
 const initialValue = "test-value";
@@ -77,25 +77,47 @@ describe("PersistedState", () => {
 		});
 	});
 
-	describe.skip("syncTabs", () => {
+	describe("syncTabs", () => {
 		testWithEffect("updates persisted value when local storage changes independently", async () => {
-			// TODO: figure out why this test is failing even though it works in the browser. maybe jsdom doesn't emit storage events?
-			// expect(true).toBe(true);
-			// const persistedState = new PersistedState(key, initialValue);
-			// localStorage.setItem(key, JSON.stringify("new-value"));
-			// await new Promise((resolve) => setTimeout(resolve, 0));
-			// expect(persistedState.current).toBe("new-value");
+			const persistedState = new PersistedState(key, initialValue);
+			await delay();
+			expect(persistedState.current).toBe(initialValue);
+			const newValue = "new-value";
+			localStorage.setItem(key, JSON.stringify(newValue));
+			const event = new StorageEvent("storage", {
+				key,
+				oldValue: initialValue,
+				newValue: JSON.stringify(newValue),
+			});
+			window.dispatchEvent(event);
+			await delay();
+			expect(persistedState.current).toBe(newValue);
 		});
 
-		// TODO: this test passes, but likely only because the storage event is not being emitted either way from jsdom
 		testWithEffect(
 			"does not update persisted value when local storage changes independently if syncTabs is false",
 			async () => {
 				const persistedState = new PersistedState(key, initialValue, { syncTabs: false });
+				await delay();
 				localStorage.setItem(key, JSON.stringify("new-value"));
-				await new Promise((resolve) => setTimeout(resolve, 0));
+				await delay();
 				expect(persistedState.current).toBe(initialValue);
 			}
 		);
+
+		testWithEffect("does not handle the storage event when 'session' storage is used", async () => {
+			const persistedState = new PersistedState(key, initialValue, { storage: "session" });
+			await delay();
+			const newValue = "new-value";
+			localStorage.setItem(key, JSON.stringify(newValue));
+			const event = new StorageEvent("storage", {
+				key,
+				oldValue: initialValue,
+				newValue: JSON.stringify(newValue),
+			});
+			window.dispatchEvent(event);
+			await delay();
+			expect(persistedState.current).toBe(initialValue);
+		});
 	});
 });

--- a/packages/runed/src/lib/utilities/PersistedState/PersistedState.test.svelte.ts
+++ b/packages/runed/src/lib/utilities/PersistedState/PersistedState.test.svelte.ts
@@ -1,7 +1,8 @@
 import { describe, expect } from "vitest";
 
-import { delay, testWithEffect } from "$lib/test/util.svelte.js";
-import { PersistedState } from "./index.js";
+import { sleep } from "$lib/internal/utils/sleep.js";
+import { testWithEffect } from "$lib/test/util.svelte.js";
+import { PersistedState } from "./PersistedState.svelte.js";
 
 const key = "test-key";
 const initialValue = "test-value";
@@ -80,7 +81,7 @@ describe("PersistedState", () => {
 	describe("syncTabs", () => {
 		testWithEffect("updates persisted value when local storage changes independently", async () => {
 			const persistedState = new PersistedState(key, initialValue);
-			await delay();
+			await sleep();
 			expect(persistedState.current).toBe(initialValue);
 			const newValue = "new-value";
 			localStorage.setItem(key, JSON.stringify(newValue));
@@ -90,7 +91,7 @@ describe("PersistedState", () => {
 				newValue: JSON.stringify(newValue),
 			});
 			window.dispatchEvent(event);
-			await delay();
+			await sleep();
 			expect(persistedState.current).toBe(newValue);
 		});
 
@@ -98,7 +99,7 @@ describe("PersistedState", () => {
 			"does not update persisted value when local storage changes independently if syncTabs is false",
 			async () => {
 				const persistedState = new PersistedState(key, initialValue, { syncTabs: false });
-				await delay();
+				await sleep();
 				const newValue = "new-value";
 				localStorage.setItem(key, JSON.stringify(newValue));
 				const event = new StorageEvent("storage", {
@@ -107,14 +108,14 @@ describe("PersistedState", () => {
 					newValue: JSON.stringify(newValue),
 				});
 				window.dispatchEvent(event);
-					await delay();
+				await sleep();
 				expect(persistedState.current).toBe(initialValue);
 			}
 		);
 
 		testWithEffect("does not handle the storage event when 'session' storage is used", async () => {
 			const persistedState = new PersistedState(key, initialValue, { storage: "session" });
-			await delay();
+			await sleep();
 			const newValue = "new-value";
 			localStorage.setItem(key, JSON.stringify(newValue));
 			const event = new StorageEvent("storage", {
@@ -123,7 +124,7 @@ describe("PersistedState", () => {
 				newValue: JSON.stringify(newValue),
 			});
 			window.dispatchEvent(event);
-			await delay();
+			await sleep();
 			expect(persistedState.current).toBe(initialValue);
 		});
 	});


### PR DESCRIPTION
Fixes #150.

## Notes

jsdom doesn't raise the 'storage' event because this event only fires when values change **in a different** window, which is something we don't have (we only have one window).  So to unit-test, one must dispatch the event manually.

Also:  The event handler uses `getValueFromStorage` to obtain the value, but the `event.newValue` property already has this value.  This seems like an unnecessary performance hit, and may be best to simply deserialize `event.newValue`.

### New Situation/Issue

I noticed that there is no deletion.  I think that whenever `this.#current` becomes undefined, the value in storage should be deleted.