### PR TITLE
Feat: Add Box

### DIFF
--- a/packages/runed/src/lib/utilities/box/box.svelte.test.ts
+++ b/packages/runed/src/lib/utilities/box/box.svelte.test.ts
@@ -1,0 +1,115 @@
+import { Derived, Ref } from "./box.svelte.js";
+
+describe("box", () => {
+	it("updates when the referenced value updates", () => {
+		let count = 0;
+		const box = Ref.to(() => count);
+		expect(box.current).toBe(0);
+
+		count = 1;
+		expect(box.current).toBe(1);
+	});
+
+	it("creates a readonly box when only a getter is passed", () => {
+		const box = Ref.to(() => 0);
+		expect(box.current).toBe(0);
+
+		function set() {
+			// @ts-expect-error
+			box.current = 1;
+		}
+
+		expect(set).toThrowError();
+	});
+
+	it("creates a writable box when a getter and setter are passed", () => {
+		let count = 0;
+		const box = Ref.to(
+			() => count,
+			(value) => {
+				count = value;
+			}
+		);
+		expect(box.current).toBe(0);
+
+		box.current = 1;
+		expect(box.current).toBe(1);
+		expect(count).toBe(1);
+
+		count = 2;
+		expect(box.current).toBe(2);
+	});
+
+	it("does not memoize the getter", () => {
+		const fn = vi.fn(() => 0);
+		const box = Ref.to(fn);
+		expect(fn).not.toHaveBeenCalled();
+
+		box.current;
+		expect(fn).toHaveBeenCalledTimes(1);
+
+		box.current;
+		expect(fn).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe("Derived", () => {
+	it("updates when the referenced value updates", () => {
+		let count = $state(0);
+		const box = Derived.by(() => count);
+		expect(box.current).toBe(0);
+
+		count = 1;
+		expect(box.current).toBe(1);
+	});
+
+	it("creates a readonly box when only a getter is passed", () => {
+		const box = Derived.by(() => 0);
+		expect(box.current).toBe(0);
+
+		function set() {
+			// @ts-expect-error
+			box.current = 1;
+		}
+
+		expect(set).toThrowError();
+	});
+
+	it("creates a writable box when a getter and setter are passed", () => {
+		let count = $state(0);
+		const box = Derived.by(
+			() => count,
+			(value) => {
+				count = value;
+			}
+		);
+		expect(box.current).toBe(0);
+
+		box.current = 1;
+		expect(box.current).toBe(1);
+		expect(count).toBe(1);
+
+		count = 2;
+		expect(box.current).toBe(2);
+	});
+
+	it("memoizes the getter", () => {
+		let count = $state(0);
+		const fn = vi.fn(() => count);
+		const box = Derived.by(fn);
+		expect(fn).not.toHaveBeenCalled();
+
+		box.current;
+		expect(fn).toHaveBeenCalledTimes(1);
+
+		box.current;
+		expect(fn).toHaveBeenCalledTimes(1);
+
+		count = 1;
+		box.current;
+		expect(fn).toHaveBeenCalledTimes(2);
+
+		box.current;
+		expect(fn).toHaveBeenCalledTimes(2);
+	});
+});

--- a/packages/runed/src/lib/utilities/box/box.svelte.ts
+++ b/packages/runed/src/lib/utilities/box/box.svelte.ts
@@ -1,0 +1,89 @@
+import type { Getter, Setter } from "$lib/internal/types.js";
+
+export type Box<T> = {
+	readonly current: T;
+	readonly get: Getter<T>;
+};
+
+export type WritableBox<T> = {
+	current: T;
+	readonly get: Getter<T>;
+	readonly set: Setter<T>;
+};
+
+export class Ref<T> implements Box<T> {
+	readonly get: Getter<T>;
+
+	constructor(get: Getter<T>) {
+		this.get = get;
+	}
+
+	static to<T>(get: Getter<T>): Box<T>;
+	static to<T>(get: Getter<T>, set: Setter<T>): WritableBox<T>;
+	static to<T>(get: Getter<T>, set?: Setter<T>): Box<T> {
+		if (set !== undefined) {
+			return new WritableRef(get, set);
+		}
+		return new Ref(get);
+	}
+
+	get current(): T {
+		return this.get();
+	}
+}
+
+class WritableRef<T> extends Ref<T> implements WritableBox<T> {
+	readonly set: Setter<T>;
+
+	constructor(get: Getter<T>, set: Setter<T>) {
+		super(get);
+		this.set = set;
+	}
+
+	get current(): T {
+		return this.get();
+	}
+
+	set current(value: T) {
+		this.set(value);
+	}
+}
+
+export class Derived<T> implements Box<T> {
+	readonly get: Getter<T>;
+
+	constructor(get: Getter<T>) {
+		const current = $derived.by(get);
+		this.get = () => current;
+	}
+
+	static by<T>(get: Getter<T>): Derived<T>;
+	static by<T>(get: Getter<T>, set: Setter<T>): WritableDerived<T>;
+	static by<T>(get: Getter<T>, set?: Setter<T>): Derived<T> {
+		if (set !== undefined) {
+			return new WritableDerived(get, set);
+		}
+		return new Derived(get);
+	}
+
+	get current(): T {
+		return this.get();
+	}
+}
+
+class WritableDerived<T> extends Derived<T> implements WritableBox<T> {
+	readonly set: Setter<T>;
+
+	constructor(get: Getter<T>, set: Setter<T>) {
+		super(get);
+		this.set = set;
+	}
+
+	get current(): T {
+		return this.get();
+	}
+
+	set current(value: T) {
+		this.set(value);
+	}
+}

--- a/packages/runed/src/lib/utilities/box/index.ts
+++ b/packages/runed/src/lib/utilities/box/index.ts
@@ -1,0 +1,1 @@
+export * from "./box.svelte.js";


### PR DESCRIPTION
# Introduction
This PR solves some of the shortcomings of when it comes to passing state across function boundaries. To preserve reactivity, you have to thunkify the argument `() => T`, but TypeScript doesn't play well with functions when it comes to type inference.

```ts
if (element() !== null) {
  element().focus(); // Type error because `element()` is still `HTMLElement | null`
}
```

The Angular team and Solid's creator Ryan both commented on a [TS issue](https://github.com/microsoft/TypeScript/issues/57725) that *may* solve this issue, but until then, we're stuck with this.

You can use `$derived.by` to turn the getter to a simple property access, but you have to do this manually for every property and for every function call. Lots of boilerplate.

```ts
function one(props: { one: () => A, two: () => B }) {
  const one = $derived.by(props.one);
  const two = $derived.by(props.two);
}

function two(props: { one: () => A, two: () => B }) {
  const one = $derived.by(props.one);
  const two = $derived.by(props.two);
}
```

Also, if the getter just simply accesses a prop, it doesn't need to be memoized. It's better to move the decision of memoization to the caller rather than the consumer.

# Ref

The first `Box` implementation is `Ref`. This is suitable for simple getters that don't need memoization like passing props around.

```ts
import { Ref, type Box } from "runed";

function useFoo(props: { foo: Box<Foo> })

let { foo }: { foo: Foo } = $props();

useFoo({
  foo: Ref.to(() => foo),
});
```

`Ref` also supports two-way binding by passing a setter as the second argument.

```ts
import { Ref, type WritableBox } from "runed";

function useInput(props: { value: WritableBox<string> })

let { value = $bindable() }: { value: string } = $props();

useInput({
  value: Ref.to(() => value, (v) => value = v),
});

```

# Derived

The second `Box` implementation is `Derived`. It's very similar to `Ref`, but use `$derived` under the hood to memoize the getter.

```ts
import { Derived, type Box } from "runed";

function useSum(props: { sum: Box<T> })

const numbers = $state([1, 2, 3, 4, 5]);

useSum({
  sum: Derived.by(() => Math.sumPrecise(numbers)),
});
```

`Derived` also supports two-way binding by passing a setter as the second argument.

```ts
import { Derived, type WritableBox } from "runed";

function useCount(props: { count: WritableBox<T> })

let count = $state(0);

useCount({
  count: Derived.by(() => count * 2, (v) => count = v / 2),
});
```

# Compatibility

Our existing utilities expect you to pass getters and setters around, which is why `Box` exposes the `get` and `set` properties.

```ts
import { StateHistory } from "runed";

const history = new StateHistory(count.get, count.set);
```