### PR TITLE
patch: additional window checks for astro

### DIFF
--- a/.changeset/clean-schools-sell.md
+++ b/.changeset/clean-schools-sell.md
@@ -1,0 +1,5 @@
+---
+"runed": patch
+---
+
+patch: add defined checks in addition to browser for `window` 

--- a/packages/runed/src/lib/internal/configurable-globals.ts
+++ b/packages/runed/src/lib/internal/configurable-globals.ts
@@ -1,4 +1,3 @@
-// configurable-globals.ts
 import { BROWSER } from "esm-env";
 
 export type ConfigurableWindow = {
@@ -28,7 +27,10 @@ export type ConfigurableLocation = {
 	location?: Location;
 };
 
-export const defaultWindow = BROWSER ? window : undefined;
-export const defaultDocument = BROWSER ? window.document : undefined;
-export const defaultNavigator = BROWSER ? window.navigator : undefined;
-export const defaultLocation = BROWSER ? window.location : undefined;
+export const defaultWindow = BROWSER && typeof window !== "undefined" ? window : undefined;
+export const defaultDocument =
+	BROWSER && typeof window !== "undefined" ? window.document : undefined;
+export const defaultNavigator =
+	BROWSER && typeof window !== "undefined" ? window.navigator : undefined;
+export const defaultLocation =
+	BROWSER && typeof window !== "undefined" ? window.location : undefined;


### PR DESCRIPTION
We started getting some issues with Astro static builds when updating to a version of Runed that has the `defaultWindow`, `defaultDocument`, etc.