### PR TITLE
docs: rename binding variable from 'el' to 'container' in on-click-outside

### DIFF
--- a/sites/docs/src/content/utilities/on-click-outside.md
+++ b/sites/docs/src/content/utilities/on-click-outside.md
@@ -32,7 +32,7 @@ components.
 	);
 </script>
 
-<div bind:this={el}>
+<div bind:this={container}>
 	<!-- Container content -->
 </div>
 <button>I'm outside the container</button>


### PR DESCRIPTION
Closes #209 