### PR TITLE
Correct StateHistory example usage in documentation

### DIFF
--- a/sites/docs/src/content/utilities/state-history.md
+++ b/sites/docs/src/content/utilities/state-history.md
@@ -31,7 +31,7 @@ Besides `log`, the returned object contains `undo` and `redo` functionality.
 <!-- prettier-ignore -->
 ```svelte
 <script lang="ts">
-	import { useStateHistory } from "runed";
+	import { StateHistory } from "runed";
 
 	let count = $state(0);
 	const history = new StateHistory(() => count, (c) => (count = c));


### PR DESCRIPTION
Hi,
Based on the StateHistory example code it seems in the documentation wrong function is imported.
This PR fixes the docs to the correct one.