### PR TITLE
fix: Fixes issue where `PersistedState` wouldn't update the `.current` value in runes mode

### DIFF
--- a/.changeset/spotty-seals-collect.md
+++ b/.changeset/spotty-seals-collect.md
@@ -1,0 +1,5 @@
+---
+"runed": patch
+---
+
+fix: Fix issues with `PersistedState` in runes mode.

--- a/.github/ISSUE_TEMPLATE/3-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/3-bug_report.yml
@@ -1,5 +1,5 @@
 name: "🐛 Bug report"
-description: Report an issue with withrunes
+description: Report an issue with runed
 body:
   - type: markdown
     attributes:
@@ -51,6 +51,6 @@ body:
       options:
         - annoyance
         - blocking an upgrade
-        - blocking all usage of WithRunes
+        - blocking all usage of runed
     validations:
       required: true

--- a/packages/runed/src/lib/utilities/persisted-state/persisted-state.test.svelte.ts
+++ b/packages/runed/src/lib/utilities/persisted-state/persisted-state.test.svelte.ts
@@ -36,10 +36,10 @@ describe("PersistedState", () => {
 		});
 
 		testWithEffect("updates localStorage when a nested property in current value changes", () => {
-			const propValue = "test"
-			const initialValue = { prop: { nested: propValue } }; 
-			const newPropValue = "new test"
-			const newValue = { prop: { nested: newPropValue } }; 
+			const propValue = "test";
+			const initialValue = { prop: { nested: propValue } };
+			const newPropValue = "new test";
+			const newValue = { prop: { nested: newPropValue } };
 			const persistedState = new PersistedState(key, initialValue);
 			expect(persistedState.current).toEqual(initialValue);
 
@@ -49,16 +49,15 @@ describe("PersistedState", () => {
 		});
 
 		testWithEffect("updates current value when localStorage changes", () => {
-			const propValue = "test"
-			const initialValue = { prop: { nested: propValue } }; 
-			const newPropValue = "new test"
-			const newValue = { prop: { nested: newPropValue } }; 
+			const propValue = "test";
+			const initialValue = { prop: { nested: propValue } };
+			const newPropValue = "new test";
+			const newValue = { prop: { nested: newPropValue } };
 			const persistedState = new PersistedState(key, initialValue);
 			expect(persistedState.current).toEqual(initialValue);
-			localStorage.setItem(key, JSON.stringify(newValue))
+			localStorage.setItem(key, JSON.stringify(newValue));
 			expect(persistedState.current).toEqual(newValue);
 		});
-
 	});
 
 	describe("sessionStorage", () => {


### PR DESCRIPTION
Fixes #235 

Adds tracking for `.#version` also ensures that `.#version` is incremented on storage events.

**Also**:
- Updated issue template to `runed` instead of `WithRunes`