### PR TITLE
docs: add license field to package.json

### DIFF
--- a/packages/runed/package.json
+++ b/packages/runed/package.json
@@ -4,6 +4,7 @@
 	"type": "module",
 	"svelte": "./dist/index.js",
 	"types": "./dist/index.d.ts",
+	"license": "MIT",
 	"contributors": [
 		{
 			"name": "Thomas G. Lopes",


### PR DESCRIPTION
Just noticed it while running my project through node-modules.dev, see https://publint.dev/runed@0.23.4