### PR TITLE
fix(pressed-keys): keys are not cleared after key combination is pressed

### DIFF
--- a/.changeset/beige-fishes-argue.md
+++ b/.changeset/beige-fishes-argue.md
@@ -1,0 +1,5 @@
+---
+"runed": minor
+---
+
+feat(PressedKeys): add the ability to register a callback to execute when a specified key combination is pressed.

--- a/.changeset/two-cameras-perform.md
+++ b/.changeset/two-cameras-perform.md
@@ -1,0 +1,5 @@
+---
+"runed": patch
+---
+
+fix(PressedKeys): keys are not cleared after key combination is pressed

--- a/packages/runed/src/lib/utilities/pressed-keys/pressed-keys.svelte.ts
+++ b/packages/runed/src/lib/utilities/pressed-keys/pressed-keys.svelte.ts
@@ -1,5 +1,7 @@
+import { on } from "svelte/events";
+import { createSubscriber } from "svelte/reactivity";
+import { watch } from "$lib/utilities/watch/index.js";
 import { defaultWindow, type ConfigurableWindow } from "$lib/internal/configurable-globals.js";
-import { useEventListener } from "../use-event-listener/use-event-listener.svelte.js";
 
 export type PressedKeysOptions = ConfigurableWindow;
 /**
@@ -9,6 +11,7 @@ export type PressedKeysOptions = ConfigurableWindow;
  */
 export class PressedKeys {
 	#pressedKeys = $state<string[]>([]);
+	readonly #subscribe?: () => void;
 
 	constructor(options: PressedKeysOptions = {}) {
 		const { window = defaultWindow } = options;
@@ -16,25 +19,89 @@ export class PressedKeys {
 
 		if (!window) return;
 
-		useEventListener(window, "keydown", (e) => {
-			const key = e.key.toLowerCase();
-			if (!this.#pressedKeys.includes(key)) {
-				this.#pressedKeys.push(key);
-			}
-		});
+		this.#subscribe = createSubscriber((update) => {
+			const keydown = on(window, "keydown", (e) => {
+				const key = e.key.toLowerCase();
+				if (!this.#pressedKeys.includes(key)) {
+					this.#pressedKeys.push(key);
+				}
+				update();
+			});
 
-		useEventListener(window, "keyup", (e) => {
-			const key = e.key.toLowerCase();
-			this.#pressedKeys = this.#pressedKeys.filter((k) => k !== key);
+			const keyup = on(window, "keyup", (e) => {
+				const key = e.key.toLowerCase();
+
+				// Special handling for modifier keys (meta, control, alt, shift)
+				// This addresses issues with OS/browser intercepting certain key combinations
+				// where non-modifier keyup events might not fire properly
+				if (["meta", "control", "alt", "shift"].includes(key)) {
+					// When a modifier key is released, clear all non-modifier keys
+					// but keep other modifier keys that might still be pressed
+					// This prevents keys from getting "stuck" in the pressed state
+					this.#pressedKeys = this.#pressedKeys.filter((k) =>
+						["meta", "control", "alt", "shift"].includes(k)
+					);
+				}
+
+				// Regular key removal
+				this.#pressedKeys = this.#pressedKeys.filter((k) => k !== key);
+				update();
+			});
+
+			// Handle window blur events (switching applications, clicking outside browser)
+			// Reset all keys when user shifts focus away from the window
+			const blur = on(window, "blur", () => {
+				this.#pressedKeys = [];
+				update();
+			});
+
+			// Handle tab visibility changes (switching browser tabs)
+			// This catches cases where the window doesn't lose focus but the tab is hidden
+			const visibilityChange = on(document, "visibilitychange", () => {
+				if (document.visibilityState === "hidden") {
+					this.#pressedKeys = [];
+					update();
+				}
+			});
+
+			return () => {
+				keydown();
+				keyup();
+				blur();
+				visibilityChange();
+			};
 		});
 	}
 
 	has(...keys: string[]): boolean {
+		this.#subscribe?.();
 		const normalizedKeys = keys.map((key) => key.toLowerCase());
 		return normalizedKeys.every((key) => this.#pressedKeys.includes(key));
 	}
 
 	get all(): string[] {
+		this.#subscribe?.();
 		return this.#pressedKeys;
+	}
+
+	/**
+	 * Registers a callback to execute when specified key combination is pressed.
+	 *
+	 * @param keys - Array or single string of keys to monitor
+	 * @param callback - Function to execute when the key combination is matched
+	 */
+	onKeys(keys: string | string[], callback: () => void) {
+		this.#subscribe?.();
+
+		const keysToMonitor = Array.isArray(keys) ? keys : [keys];
+
+		watch(
+			() => this.all,
+			() => {
+				if (this.has(...keysToMonitor)) {
+					callback();
+				}
+			}
+		);
 	}
 }

--- a/sites/docs/src/content/utilities/pressed-keys.md
+++ b/sites/docs/src/content/utilities/pressed-keys.md
@@ -27,5 +27,14 @@ Or get all of the currently pressed keys:
 
 ```ts
 const keys = new PressedKeys();
-console.log(keys.all());
+console.log(keys.all);
+```
+
+Or register a callback to execute when specified key combination is pressed:
+
+```ts
+const keys = new PressedKeys();
+keys.onKeys(["meta", "k"], () => {
+	console.log("open command palette");
+});
 ```


### PR DESCRIPTION
This PR addresses #230 and introduces an `onKey` method to register a callback to execute when a specified key combination is pressed.

I attempted to add a unit test but was not able to mock or spy on the `window` properly. 
The best approach is to use an actual browser with `@vitest/browser` and `playwright` instead of `jsdom` or `happy-dom`. However, this would introduce a lot of changes and a longer CI time, so I might create a separate PR for that.  

Closes #230 