### PR TITLE
feat: Add boolAttr utility

### DIFF
--- a/packages/runed/src/lib/utilities/bool-attr/bool-attr.svelte.ts
+++ b/packages/runed/src/lib/utilities/bool-attr/bool-attr.svelte.ts
@@ -1,0 +1,15 @@
+/**
+ * Transforms any value into `""` (empty string) or `undefined` for use with HTML attributes where presence indicates truth.
+ *
+ * Unlike directly assigning a boolean (e.g., `data-active={true}`), which often renders the string "true" as the attribute's value,
+ * this utility produces an empty string for truthy inputs (resulting in `<div data-active>`) or `undefined` for falsy inputs
+ * (resulting in the attribute being omitted entirely: `<div>`). This pattern is standard for native boolean attributes
+ * and essential for custom ones used as flags.
+ *
+ * This is particularly useful for custom `data-*` attributes that drive conditional styling (e.g., CSS selectors like `[data-state="active"]` or `[data-loading]`)
+ * or JavaScript behavior. It simplifies applying conditional states for CSS frameworks like Tailwind CSS, enabling more terse attribute-based variants
+ * such as `data-[active]:opacity-100` or `group-data-[loading]:pointer-events-none`, instead of needing to target the attribute's value (`data[active='true']:opacity-100`).
+ */
+export function boolAttr(value: unknown): "" | undefined {
+	return value ? "" : undefined;
+}

--- a/packages/runed/src/lib/utilities/bool-attr/index.ts
+++ b/packages/runed/src/lib/utilities/bool-attr/index.ts
@@ -1,0 +1,1 @@
+export { boolAttr } from "./bool-attr.svelte.js";

--- a/packages/runed/src/lib/utilities/index.ts
+++ b/packages/runed/src/lib/utilities/index.ts
@@ -22,3 +22,4 @@ export * from "./use-geolocation/index.js";
 export * from "./context/index.js";
 export * from "./is-in-viewport/index.js";
 export * from "./resource/index.js";
+export * from "./bool-attr/index.js";


### PR DESCRIPTION
*Category: **Utilities***

## Summary
This PR introduces a new utility function, `boolAttr`, designed to simplify the handling of boolean attributes in Svelte templates, especially custom `data-*` attributes.

## What it does
Inspired by SolidJS's `bool:*` directive, boolAttr controls the presence of an HTML attribute based on the truthiness of a given value:

If the input value is truthy, `boolAttr` returns an empty string (`""`). This causes the attribute to be present on the element (e.g., `<div data-active>`).

If the input value is falsy, `boolAttr` returns `undefined`. This causes Svelte to omit the attribute entirely (e.g., `<div>`).

**Example**

```svelte
<script>
    import { boolAttr } from "runed";
    let isLoading = $state(true);
    let isActive = $state(false);
</script>

<div data-loading={boolAttr(isLoading)} data-active={boolAttr(isActive)}>
  Item
</div>
```

Renders as:
```html
<div data-loading>Item</div>
```

## Why it's useful
While Svelte handles standard boolean attributes (like disabled, checked) correctly, managing the presence/absence of custom attributes often requires this specific `""`/`undefined` pattern.

Directly assigning a boolean (e.g., `data-active={true}`) typically renders the attribute with the string value "true" (`data-active="true"`). boolAttr provides a concise way to achieve the desired presence/absence behavior, which is essential for:

1. **Conditional Styling:** Using attribute presence selectors in CSS (`[data-loading] { ... }`).
2. **JavaScript Hooks:** Querying for the presence of an attribute (`element.hasAttribute('data-active')`).
3. **CSS Frameworks (like Tailwind):** Enabling more terse attribute-based variants (`data-[active]:opacity-100`, `group-data-[loading]:pointer-events-none`) without needing to target specific string values (`[data-active='true']`). *This is the use case that led me to write this utility for myself.*

This utility provides a small but helpful enhancement for developers working with conditional attributes in Svelte 5.

## Inspiration
The pattern is directly inspired by the utility and ergonomics of the `bool:*` directive in SolidJS: [SolidJS Docs - bool:*](https://docs.solidjs.com/reference/jsx-attributes/bool#bool)

---

I've only added the library code so far. If you think this is a good feature to add, I'll add the documentation page too :)