### PR TITLE
chore: update preview workflows

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -30,4 +30,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: preview-build
-          path: sites/docs/.svelte-kit/cloudflare
+          path: sites/docs/.svelte-kit
+          include-hidden-files: true

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -33,3 +33,4 @@ jobs:
           directory: ./.svelte-kit/cloudflare
           workingDirectory: sites/docs
           deploymentName: Production
+          wranglerVersion: "" # uses the local version of wrangler

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -34,4 +34,5 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           projectName: runed
           deploymentName: Preview
-          directory: ${{ steps.preview-build-artifact.outputs.download-path }}
+          directory: ${{ steps.preview-build-artifact.outputs.download-path }}/cloudflare
+          wranglerVersion: "4"


### PR DESCRIPTION
The latest version of the Cloudflare adapter no longer includes a bundle step for the generated worker file. Bundling now occurs during the deploy step instead (`refined-cf-action` takes care of this). Because of this, we now need to upload the entire `.svelte-kit` build directory as an artifact (rather than just the `.svelte-kit/cloudflare` dir).

PS: The preview for this PR won't work until the changes of `deploy-preview.yml` is on `main`.