### PR TITLE
test: fix is-idle tests and add extract tests

### DIFF
--- a/packages/runed/src/lib/test/util.svelte.ts
+++ b/packages/runed/src/lib/test/util.svelte.ts
@@ -20,7 +20,7 @@ export function effectRootScope(fn: () => void | Promise<void>): void | Promise<
 export function vitestSetTimeoutWrapper(fn: () => void, timeout: number): void {
 	setTimeout(() => {
 		fn();
-	}, timeout + 1);
+	}, timeout);
 
 	vi.advanceTimersByTime(timeout);
 }

--- a/packages/runed/src/lib/utilities/extract/extract.test.svelte.ts
+++ b/packages/runed/src/lib/utilities/extract/extract.test.svelte.ts
@@ -1,0 +1,31 @@
+import { describe, expect } from "vitest";
+import { extract } from "./extract.svelte.js";
+import { testWithEffect } from "$lib/test/util.svelte.js";
+
+describe("extract", () => {
+	testWithEffect("resolves primitive values", () => {
+		const value = 303;
+		const result = extract(value);
+		expect(result).toBe(value);
+	});
+
+	testWithEffect("resolves to default if undefined", () => {
+		const value = undefined;
+		const defaultValue = 808;
+		const result = extract(value, defaultValue);
+		expect(result).toBe(defaultValue);
+	});
+
+	testWithEffect("resolves to default if function returns undefined", () => {
+		const value = (): number | undefined => undefined;
+		const defaultValue = 808;
+		const result = extract(value, defaultValue);
+		expect(result).toBe(defaultValue);
+	});
+
+	testWithEffect("resolves to function return value", () => {
+		const value = () => 505;
+		const result = extract(value);
+		expect(result).toBe(505);
+	});
+});

--- a/packages/runed/src/lib/utilities/is-idle/is-idle.test.svelte.ts
+++ b/packages/runed/src/lib/utilities/is-idle/is-idle.test.svelte.ts
@@ -1,6 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, vi } from "vitest";
 import { IsIdle } from "./is-idle.svelte.js";
 import { testWithEffect, vitestSetTimeoutWrapper } from "$lib/test/util.svelte.js";
+import { flushSync } from "svelte";
 
 describe("IsIdle", () => {
 	beforeEach(() => {
@@ -10,7 +11,7 @@ describe("IsIdle", () => {
 		vi.clearAllTimers();
 	});
 
-	const DEFAULT_IDLE_TIME = 500;
+	const DEFAULT_IDLE_TIME = 60_000;
 	describe("Default behaviors", () => {
 		testWithEffect("Initially set to false", async () => {
 			const idleState = new IsIdle();
@@ -19,22 +20,36 @@ describe("IsIdle", () => {
 
 		testWithEffect("IsIdle is set to true when no activity occurs", async () => {
 			const idleState = new IsIdle();
-
-			vitestSetTimeoutWrapper(() => {
-				expect(idleState.current).toBe(true);
-			}, DEFAULT_IDLE_TIME);
+			flushSync();
+			vi.advanceTimersByTime(DEFAULT_IDLE_TIME + 1);
+			expect(idleState.current).toBe(true);
 		});
 
 		testWithEffect("IsIdle is set to false on click event", async () => {
 			const idleState = new IsIdle();
 
-			vitestSetTimeoutWrapper(() => {
+			flushSync();
+			vi.advanceTimersByTime(DEFAULT_IDLE_TIME + 1);
+			const input = document.createElement("input");
+			document.body.appendChild(input);
+			try {
 				expect(idleState.current).toBe(true);
-				const input = document.createElement("input");
-				document.body.appendChild(input);
 				input.click();
 				expect(idleState.current).toBe(false);
-			}, DEFAULT_IDLE_TIME);
+			} finally {
+				input.remove();
+			}
+		});
+	});
+
+	describe("lastActive", () => {
+		testWithEffect("set to last active time", () => {
+			const idleState = new IsIdle();
+			flushSync();
+			const lastActive = idleState.lastActive;
+			vi.advanceTimersByTime(200);
+			window.dispatchEvent(new Event("click"));
+			expect(idleState.lastActive).toBeGreaterThan(lastActive);
 		});
 	});
 
@@ -54,16 +69,34 @@ describe("IsIdle", () => {
 			expect(idleState.current).toBe(true);
 		});
 
-		it.skip("Events args work gets overwritten when passed in", async () => {
+		testWithEffect("Events args work gets overwritten when passed in", () => {
 			const idleState = new IsIdle({ events: ["keypress"] });
+			flushSync();
 
-			vitestSetTimeoutWrapper(() => {
-				const input = document.createElement("input");
-				document.body.appendChild(input);
+			const input = document.createElement("input");
+			document.body.appendChild(input);
+			vi.advanceTimersByTime(DEFAULT_IDLE_TIME + 1);
+			try {
 				input.click();
 				expect(idleState.current).toBe(true);
-				// TODO: add jest-dom to handle events
-			}, DEFAULT_IDLE_TIME);
+			} finally {
+				input.remove();
+			}
+		});
+	});
+
+	describe("detectVisibilityChanges", () => {
+		testWithEffect("causes activity", () => {
+			const idleState = new IsIdle({
+				detectVisibilityChanges: true,
+			});
+
+			flushSync();
+			vi.advanceTimersByTime(DEFAULT_IDLE_TIME + 1);
+			expect(idleState.current).toBe(true);
+
+			document.dispatchEvent(new Event("visibilitychange"));
+			expect(idleState.current).toBe(false);
 		});
 	});
 });


### PR DESCRIPTION
The `vitestSetTimeoutWrapper` waited for `timeout + 1`, but only advanced by `timeout`. This means the tick which the callback fires at, never happens.

The `IsIdle` tests have been "passing" because of this, but didn't actually run their assertions (the inner callback).

Also added some extra tests.
