### PR TITLE
fix: remove `#version` from persisted & don't recreate proxies

### DIFF
--- a/.changeset/tidy-items-behave.md
+++ b/.changeset/tidy-items-behave.md
@@ -1,0 +1,5 @@
+---
+"runed": patch
+---
+
+fix: remove `#version` from persisted & don't recreate proxies

--- a/packages/runed/src/lib/utilities/persisted-state/persisted-state.svelte.ts
+++ b/packages/runed/src/lib/utilities/persisted-state/persisted-state.svelte.ts
@@ -101,7 +101,11 @@ export class PersistedState<T> {
 		if (syncTabs && storageType === "local") {
 			this.#subscribe = createSubscriber((update) => {
 				this.#update = update;
-				return on(window, "storage", this.#handleStorageEvent);
+				const cleanup = on(window, "storage", this.#handleStorageEvent);
+				return () => {
+					cleanup();
+					this.#update = undefined;
+				};
 			});
 		}
 	}

--- a/packages/runed/src/lib/utilities/persisted-state/persisted-state.svelte.ts
+++ b/packages/runed/src/lib/utilities/persisted-state/persisted-state.svelte.ts
@@ -27,6 +27,36 @@ type PersistedStateOptions<T> = {
 	syncTabs?: boolean;
 } & ConfigurableWindow;
 
+function proxy<T>(
+	value: unknown,
+	root: T | undefined,
+	proxies: WeakMap<WeakKey, unknown>,
+	subscribe: VoidFunction | undefined,
+	update: VoidFunction | undefined,
+	serialize: (root?: T | undefined) => void
+): T {
+	if (value === null || value?.constructor.name === "Date" || typeof value !== "object") {
+		return value as T;
+	}
+	let p = proxies.get(value);
+	if (!p) {
+		p = new Proxy(value, {
+			get: (target, property) => {
+				subscribe?.();
+				return proxy(Reflect.get(target, property), root, proxies, subscribe, update, serialize);
+			},
+			set: (target, property, value) => {
+				update?.();
+				Reflect.set(target, property, value);
+				serialize(root);
+				return true;
+			},
+		});
+		proxies.set(value, p);
+	}
+	return p as T;
+}
+
 /**
  * Creates reactive state that is persisted and synchronized across browser sessions and tabs using Web Storage.
  * @param key The unique key used to store the state in the storage.
@@ -41,7 +71,8 @@ export class PersistedState<T> {
 	#serializer: Serializer<T>;
 	#storage?: Storage;
 	#subscribe?: VoidFunction;
-	#version = $state(0);
+	#update: VoidFunction | undefined;
+	#proxies = new WeakMap();
 
 	constructor(key: string, initialValue: T, options: PersistedStateOptions<T> = {}) {
 		const {
@@ -68,7 +99,8 @@ export class PersistedState<T> {
 		}
 
 		if (syncTabs && storageType === "local") {
-			this.#subscribe = createSubscriber(() => {
+			this.#subscribe = createSubscriber((update) => {
+				this.#update = update;
 				return on(window, "storage", this.#handleStorageEvent);
 			});
 		}
@@ -76,46 +108,28 @@ export class PersistedState<T> {
 
 	get current(): T {
 		this.#subscribe?.();
-		this.#version;
 
 		const storageItem = this.#storage?.getItem(this.#key);
 		const root = storageItem ? this.#deserialize(storageItem) : this.#current;
-
-		const proxies = new WeakMap();
-		const proxy = (value: unknown) => {
-			if (value === null || value?.constructor.name === "Date" || typeof value !== "object") {
-				return value;
-			}
-			let p = proxies.get(value);
-			if (!p) {
-				p = new Proxy(value, {
-					get: (target, property) => {
-						this.#version;
-						return proxy(Reflect.get(target, property));
-					},
-					set: (target, property, value) => {
-						this.#version += 1;
-						Reflect.set(target, property, value);
-						this.#serialize(root);
-						return true;
-					},
-				});
-				proxies.set(value, p);
-			}
-			return p;
-		};
-		return proxy(root);
+		return proxy(
+			root,
+			root,
+			this.#proxies,
+			this.#subscribe?.bind(this),
+			this.#update?.bind(this),
+			this.#serialize.bind(this)
+		);
 	}
 
 	set current(newValue: T) {
 		this.#serialize(newValue);
-		this.#version += 1;
+		this.#update?.();
 	}
 
 	#handleStorageEvent = (event: StorageEvent): void => {
 		if (event.key !== this.#key || event.newValue === null) return;
 		this.#current = this.#deserialize(event.newValue);
-		this.#version += 1;
+		this.#update?.();
 	};
 
 	#deserialize(value: string): T | undefined {


### PR DESCRIPTION
I got nerd sniped by @TGlide yesterday so this is a small refactor...there's no need to have a separate `#version` as this is basically what `createSubscriber` is doing under the hood.

I also refactored the `proxy` function externally and made sure that the proxy weak map is not recreated everytime we read current. I've added 2 or 3 tests because i noticed that we were not testing the reactivity part at all. I think we should find a way to enforce this kind of tests in every utility because with create subscriber it's very easy to skip the reactivity part if you never use it in an effect that actually needs to rerun.

Please test this thoroughly, it should work perfectly fine and I did test it myself but since the test suite is kinda lacking a bit of manual testing would be good (also if you have any other things that we should test please tell me so i can add an automated test for it)