### PR TITLE
feat(ScrollState): Add `progress.(x|y)` api

### DIFF
--- a/.changeset/famous-peas-pull.md
+++ b/.changeset/famous-peas-pull.md
@@ -1,0 +1,5 @@
+---
+"runed": patch
+---
+
+feat(ScrollState): Add `progress.(x|y)` api

--- a/packages/runed/src/lib/utilities/scroll-state/scroll-state.svelte.ts
+++ b/packages/runed/src/lib/utilities/scroll-state/scroll-state.svelte.ts
@@ -143,6 +143,10 @@ export class ScrollState {
 		top: false,
 		bottom: false,
 	});
+	progress = $state({
+		x: 0,
+		y: 0,
+	});
 
 	constructor(options: ScrollStateOptions) {
 		this.#options = options;
@@ -229,6 +233,13 @@ export class ScrollState {
 			this.arrived.top = top;
 			this.arrived.bottom = bottom;
 		}
+
+		const height = el.scrollHeight - (this.offset.bottom || 0);
+		this.progress.y = (scrollTop / (height - el.clientHeight)) * 100;
+
+		const width = el.scrollWidth - (this.offset.left || 0);
+		// Math.abs for rtl support
+		this.progress.x = Math.abs((scrollLeft / (width - el.clientWidth)) * 100);
 
 		this.internalY = scrollTop;
 	};

--- a/sites/docs/src/content/utilities/scroll-state.md
+++ b/sites/docs/src/content/utilities/scroll-state.md
@@ -53,6 +53,8 @@ You can now access:
 
 - `scroll.arrived` — whether the scroll has reached each edge
 
+- `scroll.progress` — percentage that the user has scrolled on the x/y axis
+
 - `scroll.scrollTo(x, y)` — programmatic scroll
 
 - `scroll.scrollToTop()` and `scroll.scrollToBottom()` — helpers

--- a/sites/docs/src/lib/components/demos/scroll-state.svelte
+++ b/sites/docs/src/lib/components/demos/scroll-state.svelte
@@ -18,6 +18,17 @@
 <div
 	class=" dark:bg-primary bg-background dark:ring-primary-hover dark:inset-shadow-muted/20 dark:inset-ring-muted/10 inset-ring-muted/20 ring-muted inset-shadow-muted/20 inset-ring inset-shadow-sm relative mb-4 mt-6 max-w-[760px] overflow-hidden rounded-xl ring"
 >
+	<!-- we can ditch these if you completely hate them if not remove this comment lol -->
+	<div class="absolute left-0 top-0 h-4 w-full bg-background border-b border-border">
+		<div class="relative w-full">
+			<div class="h-4 bg-[#F64A00]" style="width: {scroll.progress.y}%;"></div>
+		</div>
+	</div>
+	<div class="absolute left-0 top-0 w-4 h-full bg-background border-b border-border">
+		<div class="relative h-full">
+			<div class="w-4 bg-[#F64A00]" style="height: {scroll.progress.x}%;"></div>
+		</div>
+	</div>
 	<div class="h-[800px] overflow-scroll" bind:this={el}>
 		<div class="pattern size-[1200px]"></div>
 	</div>
@@ -65,6 +76,20 @@
 				/>
 			</Label>
 			{@render info("isScrolling", scroll.isScrolling)}
+		</div>
+
+		<hr class="border-foreground/10 mt-2 h-px border" />
+
+		<h3 class="mt-2 text-sm font-semibold">Progress</h3>
+		<div class="mt-2 grid grid-cols-5 items-center gap-4">
+			<div class="flex place-items-center gap-2">
+				<span class="text-sm font-medium leading-none">x</span>
+				<span class="text-xs text-white">{scroll.progress.x.toFixed(0)}%</span>
+			</div>
+			<div class="flex place-items-center gap-2">
+				<span class="text-sm font-medium leading-none">y</span>
+				<span class="text-xs text-white">{scroll.progress.y.toFixed(0)}%</span>
+			</div>
 		</div>
 
 		<hr class="border-foreground/10 mt-2 h-px border" />


### PR DESCRIPTION
I have found it in a few different places where it's a nice experience to have a progress indicator at the top of the screen when scrolling a form to see how far along you are.

This PR introduces a `progress.x` / `progress.y` api that allows consumers to get the percentage the user has scrolled the container in either the x or y direction. 

With this all it takes is a simple binding to the width of a container to show the progress like I have done in the example (feel free to remove).