### PR TITLE
Set initial loading state from options fields

### DIFF
--- a/packages/runed/src/lib/utilities/resource/resource.svelte.ts
+++ b/packages/runed/src/lib/utilities/resource/resource.svelte.ts
@@ -150,7 +150,7 @@ function runResource<
 
 	// Create state
 	let current = $state<Awaited<ReturnType<Fetcher>> | undefined>(initialValue);
-	let loading = $state(false);
+	let loading = $state(initialValue === undefined && !lazy);
 	let error = $state<Error | undefined>(undefined);
 	let cleanupFns = $state<Array<() => void>>([]);
 


### PR DESCRIPTION
I think it would be nice to set initial value to be computed from initialValue and lazy options. It makes sense to me because if i do not specify any of those params, i get initial loading flag as false, which then being changed to true almost instantly. That behaviour seems unclear to me and instead of doing basic "{#if someResource.loading}...{:else}" i have to do "{#if someResource.loading || !someResource.current}"