### PR TITLE
set initial loading state from options fields

### DIFF
--- a/packages/runed/src/lib/utilities/resource/resource.svelte.ts
+++ b/packages/runed/src/lib/utilities/resource/resource.svelte.ts
@@ -150,7 +150,7 @@ function runResource<
 
 	// Create state
 	let current = $state<Awaited<ReturnType<Fetcher>> | undefined>(initialValue);
-	let loading = $state(false);
+	let loading = $state(initialValue === undefined && !lazy);
 	let error = $state<Error | undefined>(undefined);
 	let cleanupFns = $state<Array<() => void>>([]);
 


### PR DESCRIPTION
Recently i ran into an issue with displaying a table with resource data. I do basic flow in markup like: ```{#if someResource.loading}...{:else if someResource.error}...{:else}<!-- working with resource data -->{/if}```. And when i try to display date like ```<td>{formatter.format(someResource.current!.user.created_at)}</td>```, i get an error saying that i am trying to display data that is undefined. After some time of debugging i found line with loading definition that is just ```let loading = $state(false)```. So this is the reason i got that error. It first tries to render block that i assume has a valid data, then starts handling loaderFn. I think it would be nice to set initial loading state that depends on params (check whether params have initial data or not + check "lazy" field).