### PR TITLE
docs: useThrottle import typo

### DIFF
--- a/sites/docs/src/content/utilities/use-throttle.md
+++ b/sites/docs/src/content/utilities/use-throttle.md
@@ -16,7 +16,7 @@ category: Utilities
 
 ```svelte
 <script lang="ts">
-	import { useThrottle, watch } from "runed";
+	import { useThrottle } from "runed";
 
 	let search = $state("");
 	let throttledSearch = $state("");


### PR DESCRIPTION
Seems like this example includes an unnecessary import of `watch`.

Apologies if I missed a build step here -- I made the fix in-browser to avoid having to clone the entire repo.