### PR TITLE
docs(use-search-params): add warning about optional default values for schema

### DIFF
--- a/.changeset/dev-warning-optional-fields.md
+++ b/.changeset/dev-warning-optional-fields.md
@@ -1,0 +1,5 @@
+---
+"runed": patch
+---
+
+Add dev mode warning when setting fields not found in schema 

--- a/packages/runed/src/lib/utilities/use-search-params/use-search-params.svelte.ts
+++ b/packages/runed/src/lib/utilities/use-search-params/use-search-params.svelte.ts
@@ -2071,6 +2071,16 @@ export function useSearchParams<Schema extends StandardSchemaV1>(
 				target.set(prop as keyof StandardSchemaV1.InferOutput<Schema> & string, value);
 				return true;
 			}
+
+			if (import.meta.env?.DEV && typeof prop === "string") {
+				console.warn(
+					`[useSearchParams] Field "${prop}" not found in schema.\n` +
+						`Either:\n` +
+						`  1. It's a typo (check your schema)\n` +
+						`  2. It's optional without default (add .default())`
+				);
+			}
+
 			return Reflect.set(target, prop, value);
 		},
 	};

--- a/sites/docs/src/content/utilities/use-search-params.md
+++ b/sites/docs/src/content/utilities/use-search-params.md
@@ -42,6 +42,19 @@ export const productSearchSchema = z.object({
 });
 ```
 
+<Callout type="warning">
+
+**All schema fields must have explicit default values.** Using `.optional()` without a default will cause fields to be silently ignored and not update the URL.
+
+```ts
+// ❌ This won't work
+z.string().optional()
+```
+
+This is because `useSearchParams` extracts field information by validating an empty object against your schema. Fields without defaults won't appear in the result, so the hook won't recognize them as valid parameters.
+
+</Callout>
+
 In your svelte code:
 
 ```svelte
@@ -479,6 +492,7 @@ const searchSchema = z.object({
 	birthDate: dateOnlyCodec.default(new Date("1990-01-15")),
 
 	// Compact product IDs
+	// Note: .optional() without default works for reading from URL, but won't be writable
 	productId: compactIdCodec.optional()
 });
 
@@ -509,6 +523,7 @@ const params = useSearchParams(searchSchema);
 		// Date-only for event date (more readable in URL)
 		eventDate: dateOnly.default(new Date()),
 		// Unix timestamp for filters (more compact)
+		// Note: .optional() without default works for reading from URL, but won't be writable
 		createdAfter: unixTimestamp.optional(),
 		updatedSince: unixTimestamp.optional()
 	});


### PR DESCRIPTION
## Summary
Adds documentation warning that schema fields using .optional() without explicit defaults will be silently ignored and cannot update the URL.

## Why
useSearchParams extracts field information by validating an empty object against the schema. Fields without defaults won't appear in the validation result, so the hook doesn't recognize them as valid parameters for URL updates.

This caused me some headache when params.fieldName = value silently failed to update the URL.