### PR TITLE
fix: using debounce inside derived

### DIFF
--- a/.changeset/free-rats-run.md
+++ b/.changeset/free-rats-run.md
@@ -1,0 +1,5 @@
+---
+"runed": minor
+---
+
+feat: added `useDebounce.raw` for use inside `$derived`

--- a/packages/runed/src/lib/utilities/use-debounce/use-debounce-reactivity.test.svelte
+++ b/packages/runed/src/lib/utilities/use-debounce/use-debounce-reactivity.test.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+	import { useDebounce } from "./use-debounce.svelte.js";
+
+	export const debounced = useDebounce(() => {}, 100);
+	debounced();
+</script>
+
+<div>pending={debounced.pending}</div>

--- a/packages/runed/src/lib/utilities/use-debounce/use-debounce.svelte.ts
+++ b/packages/runed/src/lib/utilities/use-debounce/use-debounce.svelte.ts
@@ -39,7 +39,7 @@ export function useDebounce<Args extends unknown[], Return>(
 	callback: (...args: Args) => Return,
 	wait?: MaybeGetter<number | undefined>
 ): UseDebounceReturn<Args, Return> {
-	let context = $state<DebounceContext<Return> | null>(null);
+	let context: DebounceContext<Return> | null = null;
 	const wait$ = $derived(extract(wait, 250));
 
 	function debounced(this: unknown, ...args: Args) {

--- a/packages/runed/src/lib/utilities/use-debounce/use-debounce.svelte.ts
+++ b/packages/runed/src/lib/utilities/use-debounce/use-debounce.svelte.ts
@@ -1,14 +1,13 @@
 import type { MaybeGetter } from "$lib/internal/types.js";
 import { extract } from "../extract/extract.svelte.js";
 
-type UseDebounceReturn<Args extends unknown[], Return> = ((
+type UseDebounceReturn<Args extends unknown[], Return, IncludePending extends boolean = false> = ((
 	this: unknown,
 	...args: Args
 ) => Promise<Return>) & {
 	cancel: () => void;
 	runScheduledNow: () => Promise<void>;
-	pending: boolean;
-};
+} & (IncludePending extends true ? { readonly pending: boolean } : {});
 
 type DebounceContext<Return> = {
 	timeout: ReturnType<typeof setTimeout> | null;
@@ -17,6 +16,155 @@ type DebounceContext<Return> = {
 	reject: (reason: unknown) => void;
 	promise: Promise<Return>;
 };
+
+function useDebounceInternal<
+	Args extends unknown[],
+	Return,
+	IncludePending extends boolean = false,
+>(
+	callback: (...args: Args) => Return,
+	options: {
+		/** Must be getter/setter pair to ensure reactivity */
+		context: DebounceContext<Return> | null;
+		/** Whether to include the reactive `pending` property */
+		includePending: IncludePending;
+		wait?: MaybeGetter<number | undefined>;
+	}
+): UseDebounceReturn<Args, Return, IncludePending> {
+	const wait$ = $derived(extract(options.wait, 250));
+
+	function debounced(this: unknown, ...args: Args) {
+		if (options.context) {
+			// Old context will be reused so callers awaiting the promise will get the
+			// new value
+			if (options.context.timeout) {
+				clearTimeout(options.context.timeout);
+			}
+		} else {
+			// No old context, create a new one
+			let resolve: (value: Return) => void;
+			let reject: (reason: unknown) => void;
+			const promise = new Promise<Return>((res, rej) => {
+				resolve = res;
+				reject = rej;
+			});
+
+			options.context = {
+				timeout: null,
+				runner: null,
+				promise,
+				resolve: resolve!,
+				reject: reject!,
+			};
+		}
+
+		options.context.runner = async () => {
+			// Grab the context and reset it
+			// -> new debounced calls will create a new context
+			if (!options.context) return;
+			const ctx = options.context;
+			options.context = null;
+
+			try {
+				ctx.resolve(await callback.apply(this, args));
+			} catch (error) {
+				ctx.reject(error);
+			}
+		};
+
+		options.context.timeout = setTimeout(options.context.runner, wait$);
+
+		return options.context.promise;
+	}
+
+	debounced.cancel = async () => {
+		if (!options.context || options.context.timeout === null) {
+			// Wait one event loop to see if something triggered the debounced function
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			if (!options.context || options.context.timeout === null) return;
+		}
+
+		clearTimeout(options.context.timeout);
+		options.context.reject("Cancelled");
+		options.context = null;
+	};
+
+	debounced.runScheduledNow = async () => {
+		if (!options.context || !options.context.timeout) {
+			// Wait one event loop to see if something triggered the debounced function
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			if (!options.context || !options.context.timeout) return;
+		}
+
+		clearTimeout(options.context.timeout);
+		options.context.timeout = null;
+
+		await options.context.runner?.();
+	};
+
+	if (options.includePending) {
+		Object.defineProperty(debounced, "pending", {
+			enumerable: true,
+			get() {
+				return !!options.context?.timeout;
+			},
+		});
+	}
+
+	return debounced as unknown as UseDebounceReturn<Args, Return, IncludePending>;
+}
+
+/**
+ * Non-reactive version of {@link useDebounce}.
+ *
+ * This is safe to be used inside `$derived`, but lacks the reactive `pending` property.
+ *
+ * @example
+ * ```ts
+ * const debounced = useDebounce.raw(() => {}, 100);
+ * const value = $derived(debounced());
+ * ```
+ *
+ * @see {@link https://runed.dev/docs/utilities/use-debounce}
+ *
+ * @param callback The callback to call when the time has passed.
+ * @param wait The length of time to wait in ms, defaults to 250.
+ */
+function useDebounceRaw<Args extends unknown[], Return>(
+	callback: (...args: Args) => Return,
+	wait?: MaybeGetter<number | undefined>
+): UseDebounceReturn<Args, Return, false> {
+	let context: DebounceContext<Return> | null = null;
+
+	return useDebounceInternal(callback, {
+		get context() {
+			return context;
+		},
+		set context(value) {
+			context = value;
+		},
+		wait,
+		includePending: false,
+	});
+}
+
+function useDebounce_<Args extends unknown[], Return>(
+	callback: (...args: Args) => Return,
+	wait?: MaybeGetter<number | undefined>
+): UseDebounceReturn<Args, Return, true> {
+	let context = $state<DebounceContext<Return> | null>(null);
+
+	return useDebounceInternal(callback, {
+		get context() {
+			return context;
+		},
+		set context(value) {
+			context = value;
+		},
+		wait,
+		includePending: true,
+	});
+}
 
 /**
  * Function that takes a callback, and returns a debounced version of it.
@@ -35,88 +183,6 @@ type DebounceContext<Return> = {
  * @param callback The callback to call when the time has passed.
  * @param wait The length of time to wait in ms, defaults to 250.
  */
-export function useDebounce<Args extends unknown[], Return>(
-	callback: (...args: Args) => Return,
-	wait?: MaybeGetter<number | undefined>
-): UseDebounceReturn<Args, Return> {
-	let context: DebounceContext<Return> | null = null;
-	const wait$ = $derived(extract(wait, 250));
-
-	function debounced(this: unknown, ...args: Args) {
-		if (context) {
-			// Old context will be reused so callers awaiting the promise will get the
-			// new value
-			if (context.timeout) {
-				clearTimeout(context.timeout);
-			}
-		} else {
-			// No old context, create a new one
-			let resolve: (value: Return) => void;
-			let reject: (reason: unknown) => void;
-			const promise = new Promise<Return>((res, rej) => {
-				resolve = res;
-				reject = rej;
-			});
-
-			context = {
-				timeout: null,
-				runner: null,
-				promise,
-				resolve: resolve!,
-				reject: reject!,
-			};
-		}
-
-		context.runner = async () => {
-			// Grab the context and reset it
-			// -> new debounced calls will create a new context
-			if (!context) return;
-			const ctx = context;
-			context = null;
-
-			try {
-				ctx.resolve(await callback.apply(this, args));
-			} catch (error) {
-				ctx.reject(error);
-			}
-		};
-
-		context.timeout = setTimeout(context.runner, wait$);
-
-		return context.promise;
-	}
-
-	debounced.cancel = async () => {
-		if (!context || context.timeout === null) {
-			// Wait one event loop to see if something triggered the debounced function
-			await new Promise((resolve) => setTimeout(resolve, 0));
-			if (!context || context.timeout === null) return;
-		}
-
-		clearTimeout(context.timeout);
-		context.reject("Cancelled");
-		context = null;
-	};
-
-	debounced.runScheduledNow = async () => {
-		if (!context || !context.timeout) {
-			// Wait one event loop to see if something triggered the debounced function
-			await new Promise((resolve) => setTimeout(resolve, 0));
-			if (!context || !context.timeout) return;
-		}
-
-		clearTimeout(context.timeout);
-		context.timeout = null;
-
-		await context.runner?.();
-	};
-
-	Object.defineProperty(debounced, "pending", {
-		enumerable: true,
-		get() {
-			return !!context?.timeout;
-		},
-	});
-
-	return debounced as unknown as UseDebounceReturn<Args, Return>;
-}
+export const useDebounce = Object.assign(useDebounce_, {
+	raw: useDebounceRaw,
+});

--- a/packages/runed/src/lib/utilities/use-debounce/use-debounce.test.svelte.ts
+++ b/packages/runed/src/lib/utilities/use-debounce/use-debounce.test.svelte.ts
@@ -1,6 +1,8 @@
 import { describe, expect, vi } from "vitest";
 import { useDebounce } from "./use-debounce.svelte.js";
 import { testWithEffect } from "$lib/test/util.svelte.js";
+import { render } from "@testing-library/svelte";
+import UseDebounceReactivityTest from "./use-debounce-reactivity.test.svelte";
 
 describe("useDebounce", () => {
 	testWithEffect("Function does not get called immediately", async () => {
@@ -125,8 +127,23 @@ describe("useDebounce", () => {
 		await debounced.runScheduledNow();
 	});
 
-	testWithEffect("Safe to use inside $derived", async () => {
-		const debounced = useDebounce(() => {}, 100);
+	testWithEffect("Is reactive", async () => {
+		const instance = render(UseDebounceReactivityTest);
+
+		expect(instance.component.debounced.pending).toBeTruthy();
+		expect(instance.queryByText("pending=true")).toBeInTheDocument();
+
+		await new Promise((resolve) => setTimeout(resolve, 200));
+
+		expect(instance.component.debounced.pending).toBeFalsy();
+		expect(instance.queryByText("pending=true")).not.toBeInTheDocument();
+		expect(instance.queryByText("pending=false")).toBeInTheDocument();
+
+		instance.unmount();
+	});
+
+	testWithEffect("raw is safe to use inside $derived", async () => {
+		const debounced = useDebounce.raw(() => {}, 100);
 
 		{
 			const value = $derived(debounced());

--- a/packages/runed/src/lib/utilities/use-debounce/use-debounce.test.svelte.ts
+++ b/packages/runed/src/lib/utilities/use-debounce/use-debounce.test.svelte.ts
@@ -124,4 +124,18 @@ describe("useDebounce", () => {
 		debounced().catch(() => {});
 		await debounced.runScheduledNow();
 	});
+
+	testWithEffect("Safe to use inside $derived", async () => {
+		const debounced = useDebounce(() => {}, 100);
+
+		{
+			const value = $derived(debounced());
+			await value;
+		}
+
+		{
+			const value = $derived.by(() => debounced());
+			await value;
+		}
+	});
 });

--- a/sites/docs/src/content/utilities/use-debounce.md
+++ b/sites/docs/src/content/utilities/use-debounce.md
@@ -52,3 +52,17 @@ after a specified duration of inactivity.
 <button onclick={logCount.cancel} disabled={!logCount.pending}>Cancel message</button>
 <p>{logged || "Press the button!"}</p>
 ```
+
+---
+
+If you need to use this utility inside `$derived`, you can use `useDebounce.raw` instead. This has
+the downside of not having reactive properties like `pending`.
+
+```svelte
+<script lang="ts">
+	import { useDebounce } from "runed";
+
+	const debounced = useDebounce.raw(() => {}, 100);
+	const value = $derived(debounced());
+</script>
+```


### PR DESCRIPTION
# Problem

The following code snippet throws an error as the internal context `$state` is updated when calling the debounced function. Mutating `$state` inside `$derived` is forbidden in Svelte.

```ts
const debounced = useDebounce(() => {}, 100);
const value = $derived(debounced());
```

# Solution

For lack of a better solution, I implemented a sub-utility `useDebounce.raw` that does not use reactive state, so it is safe to be used inside `$derived`.

```ts
const debounced = useDebounce.raw(() => {}, 100);
const value = $derived(debounced());
// Does not expose debounced.pending as it is not reactive
```

I'm not 100% happy with this solution, so you are welcome to change it or make suggestions for improvements :) 