### PR TITLE
fix(useDebounce, useThrottle): prevent unhandled rejection on cancel

### DIFF
--- a/.changeset/thin-carpets-beam.md
+++ b/.changeset/thin-carpets-beam.md
@@ -1,0 +1,5 @@
+---
+"runed": patch
+---
+
+fix(useDebounce, useThrottle): resolve instead of reject on cancel

--- a/packages/runed/src/lib/utilities/use-debounce/use-debounce.svelte.ts
+++ b/packages/runed/src/lib/utilities/use-debounce/use-debounce.svelte.ts
@@ -57,6 +57,9 @@ export function useDebounce<Args extends unknown[], Return>(
 				resolve = res;
 				reject = rej;
 			});
+			// Prevent unhandled rejection when cancel() is called
+			// without the caller attaching a .catch() handler
+			promise.catch(() => {});
 
 			context = {
 				timeout: null,

--- a/packages/runed/src/lib/utilities/use-throttle/use-throttle.svelte.ts
+++ b/packages/runed/src/lib/utilities/use-throttle/use-throttle.svelte.ts
@@ -37,6 +37,9 @@ export function useThrottle<Args extends unknown[], Return>(
 					resolve = res;
 					reject = rej;
 				});
+				// Prevent unhandled rejection when cancel() is called
+				// without the caller attaching a .catch() handler
+				promise.catch(() => {});
 			}
 
 			if (now < nextAllowedTime) {


### PR DESCRIPTION
Calling `cancel()` rejects the pending promise with `"Cancelled"`, which throws an `Uncaught (in promise) Cancelled` error when the caller doesn't have a `.catch()` handler attached (fire-and-forget usage).

This adds an internal no-op `.catch()` to the promise when it's created, so the rejection is always handled internally. Callers who explicitly use `.catch()` or `await` + try/catch still receive the rejection as before.

The same fix is applied to `useThrottle` which has the identical issue (noted in the comments on #365).

Closes #365